### PR TITLE
feat(TEST): Create a simple to-do feature (use localStorage) make it as  [DUMMY-29]

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,1 @@
+<app-todo></app-todo>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { TodoComponent } from './todo/todo.component';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TodoComponent],
+  template: `<app-todo></app-todo>`,
+})
+export class AppComponent {}

--- a/src/app/todo/todo.component.html
+++ b/src/app/todo/todo.component.html
@@ -1,0 +1,41 @@
+<div class="todo-container">
+  <h1>To-Do List</h1>
+
+  <div class="todo-input-row">
+    <input
+      type="text"
+      [(ngModel)]="newTask"
+      (keyup.enter)="addTask()"
+      placeholder="Enter a new task..."
+      aria-label="New task input"
+      class="todo-input"
+    />
+    <button
+      (click)="addTask()"
+      class="btn-add"
+      aria-label="Add task"
+    >
+      Add
+    </button>
+  </div>
+
+  <ul class="todo-list" aria-label="Task list">
+    <li
+      *ngFor="let task of tasks; let i = index"
+      class="todo-item"
+    >
+      <span class="todo-item-text">{{ task }}</span>
+      <button
+        (click)="deleteTask(i)"
+        class="btn-delete"
+        [attr.aria-label]="'Delete task: ' + task"
+      >
+        Delete
+      </button>
+    </li>
+  </ul>
+
+  <p *ngIf="tasks.length === 0" class="todo-empty" aria-live="polite">
+    No tasks yet. Add one above!
+  </p>
+</div>

--- a/src/app/todo/todo.component.spec.ts
+++ b/src/app/todo/todo.component.spec.ts
@@ -1,0 +1,265 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TodoComponent } from './todo.component';
+
+describe('TodoComponent', () => {
+  let component: TodoComponent;
+  let fixture: ComponentFixture<TodoComponent>;
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(async () => {
+    localStorageMock = {};
+
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(
+      (key: string) => localStorageMock[key] ?? null
+    );
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(
+      (key: string, value: string) => {
+        localStorageMock[key] = value;
+      }
+    );
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(
+      (key: string) => {
+        delete localStorageMock[key];
+      }
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [TodoComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TodoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initialisation
+  // ---------------------------------------------------------------------------
+
+  describe('initialisation', () => {
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should start with an empty list when localStorage has no data', () => {
+      expect(component.todos).toEqual([]);
+    });
+
+    it('should load existing tasks from localStorage on init', async () => {
+      const stored = ['Buy milk', 'Walk the dog'];
+      localStorageMock['todo-items'] = JSON.stringify(stored);
+
+      // Re-create the component so ngOnInit reads the pre-populated store
+      await TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TodoComponent],
+      }).compileComponents();
+
+      const newFixture = TestBed.createComponent(TodoComponent);
+      const newComponent = newFixture.componentInstance;
+      newFixture.detectChanges();
+
+      expect(newComponent.todos).toEqual(stored);
+    });
+
+    it('should handle malformed localStorage data gracefully', async () => {
+      localStorageMock['todo-items'] = 'not-valid-json{{';
+
+      await TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TodoComponent],
+      }).compileComponents();
+
+      const newFixture = TestBed.createComponent(TodoComponent);
+      const newComponent = newFixture.componentInstance;
+      newFixture.detectChanges();
+
+      expect(newComponent.todos).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Add task
+  // ---------------------------------------------------------------------------
+
+  describe('addTodo()', () => {
+    it('should add a valid task to the list', () => {
+      component.newTodo = 'Write unit tests';
+      component.addTodo();
+
+      expect(component.todos).toContain('Write unit tests');
+    });
+
+    it('should persist the new task to localStorage', () => {
+      component.newTodo = 'Write unit tests';
+      component.addTodo();
+
+      const stored = JSON.parse(localStorageMock['todo-items']);
+      expect(stored).toContain('Write unit tests');
+    });
+
+    it('should clear the input field after adding a task', () => {
+      component.newTodo = 'Write unit tests';
+      component.addTodo();
+
+      expect(component.newTodo).toBe('');
+    });
+
+    it('should support adding multiple tasks', () => {
+      component.newTodo = 'Task one';
+      component.addTodo();
+      component.newTodo = 'Task two';
+      component.addTodo();
+
+      expect(component.todos).toEqual(['Task one', 'Task two']);
+    });
+
+    it('should NOT add an empty string task', () => {
+      component.newTodo = '';
+      component.addTodo();
+
+      expect(component.todos).toHaveLength(0);
+    });
+
+    it('should NOT add a whitespace-only task', () => {
+      component.newTodo = '   ';
+      component.addTodo();
+
+      expect(component.todos).toHaveLength(0);
+    });
+
+    it('should NOT modify localStorage when task is empty', () => {
+      component.newTodo = '';
+      component.addTodo();
+
+      expect(localStorageMock['todo-items']).toBeUndefined();
+    });
+
+    it('should NOT modify localStorage when task is whitespace-only', () => {
+      component.newTodo = '   ';
+      component.addTodo();
+
+      expect(localStorageMock['todo-items']).toBeUndefined();
+    });
+
+    it('should trim leading/trailing whitespace before adding', () => {
+      component.newTodo = '  Buy groceries  ';
+      component.addTodo();
+
+      expect(component.todos).toContain('Buy groceries');
+      expect(component.todos).not.toContain('  Buy groceries  ');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delete task
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTodo()', () => {
+    beforeEach(() => {
+      component.newTodo = 'Task A';
+      component.addTodo();
+      component.newTodo = 'Task B';
+      component.addTodo();
+      component.newTodo = 'Task C';
+      component.addTodo();
+    });
+
+    it('should remove the task at the given index', () => {
+      component.deleteTodo(1); // removes 'Task B'
+
+      expect(component.todos).toEqual(['Task A', 'Task C']);
+    });
+
+    it('should persist the updated list to localStorage after deletion', () => {
+      component.deleteTodo(0); // removes 'Task A'
+
+      const stored = JSON.parse(localStorageMock['todo-items']);
+      expect(stored).toEqual(['Task B', 'Task C']);
+    });
+
+    it('should remove the first task correctly', () => {
+      component.deleteTodo(0);
+
+      expect(component.todos[0]).toBe('Task B');
+      expect(component.todos).toHaveLength(2);
+    });
+
+    it('should remove the last task correctly', () => {
+      component.deleteTodo(2);
+
+      expect(component.todos).toEqual(['Task A', 'Task B']);
+    });
+
+    it('should result in an empty list when the only task is deleted', () => {
+      // Reset to a single-item list
+      component.todos = ['Only task'];
+      component.deleteTodo(0);
+
+      expect(component.todos).toHaveLength(0);
+    });
+
+    it('should persist an empty array to localStorage when last task is deleted', () => {
+      component.todos = ['Only task'];
+      component.deleteTodo(0);
+
+      const stored = JSON.parse(localStorageMock['todo-items']);
+      expect(stored).toEqual([]);
+    });
+
+    it('should not affect other tasks when one is deleted', () => {
+      const before = [...component.todos];
+      component.deleteTodo(1);
+
+      expect(component.todos).toHaveLength(before.length - 1);
+      expect(component.todos).toContain('Task A');
+      expect(component.todos).toContain('Task C');
+      expect(component.todos).not.toContain('Task B');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Template / DOM integration
+  // ---------------------------------------------------------------------------
+
+  describe('template integration', () => {
+    it('should render a task in the DOM after adding it', () => {
+      component.newTodo = 'Render me';
+      component.addTodo();
+      fixture.detectChanges();
+
+      const compiled: HTMLElement = fixture.nativeElement;
+      expect(compiled.textContent).toContain('Render me');
+    });
+
+    it('should remove a task from the DOM after deleting it', () => {
+      component.newTodo = 'Delete me';
+      component.addTodo();
+      fixture.detectChanges();
+
+      component.deleteTodo(0);
+      fixture.detectChanges();
+
+      const compiled: HTMLElement = fixture.nativeElement;
+      expect(compiled.textContent).not.toContain('Delete me');
+    });
+
+    it('should render all tasks in the DOM', () => {
+      ['Alpha', 'Beta', 'Gamma'].forEach((t) => {
+        component.newTodo = t;
+        component.addTodo();
+      });
+      fixture.detectChanges();
+
+      const compiled: HTMLElement = fixture.nativeElement;
+      expect(compiled.textContent).toContain('Alpha');
+      expect(compiled.textContent).toContain('Beta');
+      expect(compiled.textContent).toContain('Gamma');
+    });
+  });
+});

--- a/src/app/todo/todo.component.ts
+++ b/src/app/todo/todo.component.ts
@@ -1,0 +1,180 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+const STORAGE_KEY = 'todo-items';
+
+@Component({
+  selector: 'app-todo',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="todo-container">
+      <h1>To-Do List</h1>
+
+      <div class="todo-input-row">
+        <input
+          type="text"
+          [(ngModel)]="newTask"
+          placeholder="Enter a new task..."
+          (keyup.enter)="addTask()"
+          aria-label="New task input"
+        />
+        <button (click)="addTask()" type="button">Add</button>
+      </div>
+
+      <ul class="todo-list" *ngIf="tasks.length > 0; else emptyState">
+        <li *ngFor="let task of tasks; let i = index" class="todo-item">
+          <span class="todo-text">{{ task }}</span>
+          <button
+            (click)="deleteTask(i)"
+            type="button"
+            class="delete-btn"
+            [attr.aria-label]="'Delete task: ' + task"
+          >
+            Delete
+          </button>
+        </li>
+      </ul>
+
+      <ng-template #emptyState>
+        <p class="empty-state">No tasks yet. Add one above!</p>
+      </ng-template>
+    </div>
+  `,
+  styles: [
+    `
+      .todo-container {
+        max-width: 480px;
+        margin: 2rem auto;
+        font-family: sans-serif;
+      }
+
+      .todo-input-row {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .todo-input-row input {
+        flex: 1;
+        padding: 0.5rem;
+        font-size: 1rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+
+      .todo-input-row button {
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        background-color: #1976d2;
+        color: #fff;
+      }
+
+      .todo-input-row button:hover {
+        background-color: #1565c0;
+      }
+
+      .todo-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .todo-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #eee;
+      }
+
+      .todo-item:last-child {
+        border-bottom: none;
+      }
+
+      .todo-text {
+        flex: 1;
+        word-break: break-word;
+      }
+
+      .delete-btn {
+        margin-left: 1rem;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.875rem;
+        cursor: pointer;
+        border: 1px solid #e53935;
+        border-radius: 4px;
+        background-color: transparent;
+        color: #e53935;
+        flex-shrink: 0;
+      }
+
+      .delete-btn:hover {
+        background-color: #e53935;
+        color: #fff;
+      }
+
+      .empty-state {
+        color: #888;
+        font-style: italic;
+      }
+    `,
+  ],
+})
+export class TodoComponent implements OnInit {
+  tasks: string[] = [];
+  newTask = '';
+
+  ngOnInit(): void {
+    this.tasks = this.loadFromStorage();
+  }
+
+  addTask(): void {
+    const trimmed = this.newTask.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.tasks = [...this.tasks, trimmed];
+    this.newTask = '';
+    this.saveToStorage(this.tasks);
+  }
+
+  deleteTask(index: number): void {
+    if (index < 0 || index >= this.tasks.length) {
+      return;
+    }
+    this.tasks = this.tasks.filter((_, i) => i !== index);
+    this.saveToStorage(this.tasks);
+  }
+
+  private loadFromStorage(): string[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      // Ensure every element is a non-empty string; silently drop corrupt entries.
+      return parsed.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+    } catch {
+      // Corrupted JSON or storage unavailable — start fresh.
+      return [];
+    }
+  }
+
+  private saveToStorage(tasks: string[]): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+    } catch {
+      // Storage quota exceeded or unavailable — fail silently.
+      console.warn('TodoComponent: unable to persist tasks to localStorage.');
+    }
+  }
+}


### PR DESCRIPTION
## Story
**DUMMY-29**: ## Context

## Acceptance Criteria
- Given the to-do list is open, when the user types a non-empty task and clicks 'Add', then the task appears in the list immediately and is persisted in localStorage under the key 'todo-items'.
- Given tasks exist in localStorage, when the page is refreshed, then all previously saved tasks are displayed in the list without data loss.
- Given a task is visible in the list, when the user clicks its 'Delete' button, then the task is removed from the list and the updated list is saved to localStorage.
- Given the user attempts to add an empty or whitespace-only task and clicks 'Add', then no task is added to the list and localStorage is not modified.

## Implementation Details
Implements: Create a simple to-do feature (use localStorage) make it as simple as possible

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖
