### PR TITLE
feat(SAM1): Let's create a basic to-do feature to the app (no backend, j [SAM1-164]

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,10 +2,12 @@ import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { AnalyticsService, ConsoleAnalyticsService } from './core/analytics.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    { provide: AnalyticsService, useClass: ConsoleAnalyticsService },
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'todos', pathMatch: 'full' },
+  {
+    path: 'todos',
+    loadComponent: () =>
+      import('./features/todo/todo-list.component').then(m => m.TodoListComponent),
+  },
+];

--- a/src/app/core/analytics.service.ts
+++ b/src/app/core/analytics.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+export abstract class AnalyticsService {
+  abstract track(event: string, meta: Record<string, unknown>): void;
+}
+
+@Injectable()
+export class ConsoleAnalyticsService extends AnalyticsService {
+  track(event: string, meta: Record<string, unknown>): void {
+    console.log(`[Analytics] ${event}`, meta);
+  }
+}

--- a/src/app/core/storage-adapter.service.ts
+++ b/src/app/core/storage-adapter.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class StorageAdapter {
+  readonly storageAvailable = signal(false);
+
+  constructor() {
+    this.storageAvailable.set(this.detectStorage());
+  }
+
+  private detectStorage(): boolean {
+    try {
+      const testKey = '__storage_test__';
+      localStorage.setItem(testKey, 'test');
+      const result = localStorage.getItem(testKey);
+      localStorage.removeItem(testKey);
+      return result === 'test';
+    } catch {
+      return false;
+    }
+  }
+
+  read<T>(key: string): T | null {
+    if (!this.storageAvailable()) return null;
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return null;
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  write(key: string, data: unknown): boolean {
+    if (!this.storageAvailable()) return false;
+    try {
+      localStorage.setItem(key, JSON.stringify(data));
+      return true;
+    } catch (e) {
+      if (e instanceof DOMException && (e.name === 'QuotaExceededError' || e.code === 22)) {
+        return false;
+      }
+      return false;
+    }
+  }
+}

--- a/src/app/features/todo/__tests__/todo-item.component.spec.ts
+++ b/src/app/features/todo/__tests__/todo-item.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TodoItemComponent } from '../todo-item.component';
+import { Todo } from '../todo.model';
+import { ComponentRef } from '@angular/core';
+
+describe('TodoItemComponent', () => {
+  let fixture: ComponentFixture<TodoItemComponent>;
+  let componentRef: ComponentRef<TodoItemComponent>;
+  let el: HTMLElement;
+
+  const baseTodo: Todo = {
+    id: '1',
+    title: 'Test todo',
+    completed: false,
+    createdAt: '2024-01-01T00:00:00Z',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TodoItemComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TodoItemComponent);
+    componentRef = fixture.componentRef;
+    el = fixture.nativeElement;
+  });
+
+  it('should render title', () => {
+    componentRef.setInput('todo', baseTodo);
+    fixture.detectChanges();
+    const label = el.querySelector('.todo-label') as HTMLElement;
+    expect(label.textContent?.trim()).toBe('Test todo');
+  });
+
+  it('should reflect checkbox state', () => {
+    componentRef.setInput('todo', { ...baseTodo, completed: true });
+    fixture.detectChanges();
+    const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('should apply completed class', () => {
+    componentRef.setInput('todo', { ...baseTodo, completed: true });
+    fixture.detectChanges();
+    expect(el.querySelector('.todo-item.completed')).toBeTruthy();
+  });
+
+  it('should emit toggled on checkbox change', () => {
+    componentRef.setInput('todo', baseTodo);
+    fixture.detectChanges();
+    let emittedId: string | undefined;
+    fixture.componentInstance.toggled.subscribe((id: string) => (emittedId = id));
+    const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.dispatchEvent(new Event('change'));
+    expect(emittedId).toBe('1');
+  });
+
+  it('should emit deleted on button click', () => {
+    componentRef.setInput('todo', baseTodo);
+    fixture.detectChanges();
+    let emittedId: string | undefined;
+    fixture.componentInstance.deleted.subscribe((id: string) => (emittedId = id));
+    const btn = el.querySelector('.todo-delete') as HTMLButtonElement;
+    btn.click();
+    expect(emittedId).toBe('1');
+  });
+
+  it('should have correct aria-label on delete button', () => {
+    componentRef.setInput('todo', baseTodo);
+    fixture.detectChanges();
+    const btn = el.querySelector('.todo-delete') as HTMLButtonElement;
+    expect(btn.getAttribute('aria-label')).toBe('Delete todo: Test todo');
+  });
+
+  it('should have title attribute on label for long text', () => {
+    componentRef.setInput('todo', baseTodo);
+    fixture.detectChanges();
+    const label = el.querySelector('.todo-label') as HTMLElement;
+    expect(label.getAttribute('title')).toBe('Test todo');
+  });
+});

--- a/src/app/features/todo/__tests__/todo-list.component.spec.ts
+++ b/src/app/features/todo/__tests__/todo-list.component.spec.ts
@@ -1,0 +1,332 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TodoListComponent } from '../todo-list.component';
+import { TodoService, ID_GENERATOR } from '../todo.service';
+import { StorageAdapter } from '../../../core/storage-adapter.service';
+import { AnalyticsService } from '../../../core/analytics.service';
+import { TodoStore } from '../todo.model';
+import { signal } from '@angular/core';
+
+class MockAnalyticsService extends AnalyticsService {
+  events: { event: string; meta: Record<string, unknown> }[] = [];
+  track(event: string, meta: Record<string, unknown>): void {
+    this.events.push({ event, meta });
+  }
+}
+
+describe('TodoListComponent', () => {
+  let fixture: ComponentFixture<TodoListComponent>;
+  let component: TodoListComponent;
+  let el: HTMLElement;
+  let analytics: MockAnalyticsService;
+  let storage: Record<string, string>;
+  let storageAvailable: boolean;
+  let idCounter: number;
+
+  function createComponent(preStorage?: Record<string, string>) {
+    storage = preStorage ?? {};
+    storageAvailable = true;
+    analytics = new MockAnalyticsService();
+    idCounter = 0;
+
+    TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [
+        TodoService,
+        {
+          provide: StorageAdapter,
+          useFactory: () => {
+            const svc = {
+              storageAvailable: signal(storageAvailable),
+              read: (key: string) => {
+                if (!storageAvailable) return null;
+                const raw = storage[key];
+                return raw ? JSON.parse(raw) : null;
+              },
+              write: (key: string, data: unknown) => {
+                if (!storageAvailable) return false;
+                storage[key] = JSON.stringify(data);
+                return true;
+              },
+            };
+            return svc;
+          },
+        },
+        { provide: AnalyticsService, useFactory: () => analytics },
+        { provide: ID_GENERATOR, useValue: () => `id-${++idCounter}` },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+    el = fixture.nativeElement;
+    fixture.detectChanges();
+  }
+
+  function createComponentStorageUnavailable() {
+    storage = {};
+    storageAvailable = false;
+    analytics = new MockAnalyticsService();
+    idCounter = 0;
+
+    TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [
+        TodoService,
+        {
+          provide: StorageAdapter,
+          useFactory: () => ({
+            storageAvailable: signal(false),
+            read: () => null,
+            write: () => false,
+          }),
+        },
+        { provide: AnalyticsService, useFactory: () => analytics },
+        { provide: ID_GENERATOR, useValue: () => `id-${++idCounter}` },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+    el = fixture.nativeElement;
+    fixture.detectChanges();
+  }
+
+  function getInput(): HTMLInputElement {
+    return el.querySelector('.todo-input') as HTMLInputElement;
+  }
+
+  function submitTodo(title: string): void {
+    const input = getInput();
+    input.value = title;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    // Set inputValue signal via ngModel
+    component['inputValue'].set(title);
+    component.onSubmit();
+    fixture.detectChanges();
+  }
+
+  function getFilterButtons(): HTMLButtonElement[] {
+    return Array.from(el.querySelectorAll('.filter-btn'));
+  }
+
+  function clickFilter(label: string): void {
+    const btn = getFilterButtons().find(b => b.textContent?.trim() === label);
+    btn?.click();
+    fixture.detectChanges();
+  }
+
+  // --- Add Todo ---
+
+  it('should add a todo on submit and clear input', () => {
+    createComponent();
+    submitTodo('Buy milk');
+    expect(el.querySelector('.todo-label')?.textContent?.trim()).toBe('Buy milk');
+    expect(component['inputValue']()).toBe('');
+  });
+
+  it('should persist todo to localStorage with versioned schema', () => {
+    createComponent();
+    submitTodo('Buy milk');
+    const stored: TodoStore = JSON.parse(storage['todos_app_data']);
+    expect(stored.version).toBe(1);
+    expect(stored.todos.length).toBe(1);
+    expect(stored.todos[0].title).toBe('Buy milk');
+  });
+
+  // --- Whitespace / Empty Input ---
+
+  it('should not add todo for empty input', () => {
+    createComponent();
+    submitTodo('');
+    expect(el.querySelectorAll('app-todo-item').length).toBe(0);
+  });
+
+  it('should not add todo for whitespace-only input', () => {
+    createComponent();
+    submitTodo('   ');
+    expect(el.querySelectorAll('app-todo-item').length).toBe(0);
+  });
+
+  // --- Toggle ---
+
+  it('should toggle a todo when checkbox changes', () => {
+    createComponent();
+    submitTodo('Test');
+    const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(el.querySelector('.todo-item.completed')).toBeTruthy();
+  });
+
+  // --- Delete ---
+
+  it('should remove a todo when delete button clicked', () => {
+    createComponent();
+    submitTodo('Test');
+    const deleteBtn = el.querySelector('.todo-delete') as HTMLButtonElement;
+    deleteBtn.click();
+    fixture.detectChanges();
+    expect(el.querySelectorAll('app-todo-item').length).toBe(0);
+  });
+
+  // --- Filter ---
+
+  it('should filter active todos', () => {
+    createComponent();
+    submitTodo('Active one');
+    submitTodo('Done one');
+    // Toggle second (which is first in list since prepended)
+    const checkboxes = el.querySelectorAll('input[type="checkbox"]');
+    checkboxes[0].dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    clickFilter('Active');
+    expect(el.querySelectorAll('app-todo-item').length).toBe(1);
+  });
+
+  it('should filter completed todos', () => {
+    createComponent();
+    submitTodo('Active one');
+    submitTodo('Done one');
+    const checkboxes = el.querySelectorAll('input[type="checkbox"]');
+    checkboxes[0].dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    clickFilter('Completed');
+    expect(el.querySelectorAll('app-todo-item').length).toBe(1);
+  });
+
+  it('should show all todos with All filter', () => {
+    createComponent();
+    submitTodo('One');
+    submitTodo('Two');
+    const checkboxes = el.querySelectorAll('input[type="checkbox"]');
+    checkboxes[0].dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    clickFilter('Completed');
+    clickFilter('All');
+    expect(el.querySelectorAll('app-todo-item').length).toBe(2);
+  });
+
+  it('should fire todo_filter_changed analytics event', () => {
+    createComponent();
+    clickFilter('Active');
+    expect(analytics.events.some(e => e.event === 'todo_filter_changed' && (e.meta as any).filter === 'active')).toBe(true);
+  });
+
+  // --- Items Left Counter ---
+
+  it('should show items left counter with plural', () => {
+    createComponent();
+    submitTodo('One');
+    submitTodo('Two');
+    const counter = el.querySelector('.items-left')?.textContent?.trim();
+    expect(counter).toBe('2 items left');
+  });
+
+  it('should show singular item left', () => {
+    createComponent();
+    submitTodo('One');
+    const counter = el.querySelector('.items-left')?.textContent?.trim();
+    expect(counter).toBe('1 item left');
+  });
+
+  it('should show 0 items left', () => {
+    createComponent();
+    const counter = el.querySelector('.items-left')?.textContent?.trim();
+    expect(counter).toBe('0 items left');
+  });
+
+  // --- Empty States ---
+
+  it('should show first-run empty state message', () => {
+    createComponent();
+    expect(el.querySelector('.empty-state')?.textContent?.trim()).toBe('Add your first task above to get started');
+  });
+
+  it('should not show first-run message after adding a todo', () => {
+    createComponent();
+    submitTodo('First');
+    expect(el.querySelector('.empty-state')).toBeFalsy();
+  });
+
+  it('should show "No completed tasks yet" for completed filter with none completed', () => {
+    createComponent();
+    submitTodo('Active');
+    clickFilter('Completed');
+    expect(el.querySelector('.empty-state')?.textContent?.trim()).toBe('No completed tasks yet');
+  });
+
+  it('should show "Everything is done!" for active filter when all completed', () => {
+    createComponent();
+    submitTodo('Done');
+    const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    clickFilter('Active');
+    expect(el.querySelector('.empty-state')?.textContent?.trim()).toContain('Everything is done!');
+  });
+
+  // --- Storage Warning ---
+
+  it('should show storage unavailable banner', () => {
+    createComponentStorageUnavailable();
+    const banner = el.querySelector('.warning-banner');
+    expect(banner?.textContent).toContain("Your browser doesn't support local storage");
+  });
+
+  it('should not show storage banner when available', () => {
+    createComponent();
+    expect(el.querySelector('.warning-banner')).toBeFalsy();
+  });
+
+  // --- Accessibility ---
+
+  it('should have aria-pressed on filter buttons', () => {
+    createComponent();
+    const buttons = getFilterButtons();
+    const allBtn = buttons.find(b => b.textContent?.trim() === 'All');
+    expect(allBtn?.getAttribute('aria-pressed')).toBe('true');
+    const activeBtn = buttons.find(b => b.textContent?.trim() === 'Active');
+    expect(activeBtn?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('should have section with aria-label', () => {
+    createComponent();
+    const section = el.querySelector('section[aria-label="Todo list"]');
+    expect(section).toBeTruthy();
+  });
+
+  it('should have maxlength on input', () => {
+    createComponent();
+    expect(getInput().getAttribute('maxlength')).toBe('250');
+  });
+
+  // --- Persistence ---
+
+  it('should load persisted todos on construction', () => {
+    const store: TodoStore = {
+      version: 1,
+      todos: [{ id: 'x', title: 'Persisted', completed: false, createdAt: '2024-01-01T00:00:00Z' }],
+    };
+    createComponent({ 'todos_app_data': JSON.stringify(store) });
+    expect(el.querySelector('.todo-label')?.textContent?.trim()).toBe('Persisted');
+  });
+
+  // --- Quota exceeded warning ---
+
+  it('should show inline warning when write fails', () => {
+    createComponent();
+    // Make writes fail after initial setup
+    const adapter = TestBed.inject(StorageAdapter);
+    (adapter as any).write = () => false;
+    // Need to also set storageAvailable to true so add works in-memory
+    submitTodo('Test');
+    fixture.detectChanges();
+    const warning = el.querySelector('.warning-inline');
+    expect(warning?.textContent).toContain('Storage full');
+  });
+});

--- a/src/app/features/todo/__tests__/todo.service.spec.ts
+++ b/src/app/features/todo/__tests__/todo.service.spec.ts
@@ -1,0 +1,151 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoService, ID_GENERATOR } from '../todo.service';
+import { StorageAdapter } from '../../../core/storage-adapter.service';
+import { AnalyticsService } from '../../../core/analytics.service';
+import { TodoStore } from '../todo.model';
+
+class MockAnalyticsService extends AnalyticsService {
+  events: { event: string; meta: Record<string, unknown> }[] = [];
+  track(event: string, meta: Record<string, unknown>): void {
+    this.events.push({ event, meta });
+  }
+}
+
+describe('TodoService', () => {
+  let service: TodoService;
+  let analytics: MockAnalyticsService;
+  let storage: Record<string, string>;
+  let storageAvailable: boolean;
+  let idCounter: number;
+
+  function createService() {
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        {
+          provide: StorageAdapter,
+          useValue: {
+            storageAvailable: () => storageAvailable,
+            read: (key: string) => {
+              if (!storageAvailable) return null;
+              const raw = storage[key];
+              return raw ? JSON.parse(raw) : null;
+            },
+            write: (key: string, data: unknown) => {
+              if (!storageAvailable) return false;
+              storage[key] = JSON.stringify(data);
+              return true;
+            },
+          },
+        },
+        { provide: AnalyticsService, useValue: analytics },
+        { provide: ID_GENERATOR, useValue: () => `id-${++idCounter}` },
+      ],
+    });
+    service = TestBed.inject(TodoService);
+  }
+
+  beforeEach(() => {
+    storage = {};
+    storageAvailable = true;
+    analytics = new MockAnalyticsService();
+    idCounter = 0;
+  });
+
+  it('should add a todo and persist', () => {
+    createService();
+    service.add('Buy milk');
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Buy milk');
+    expect(service.todos()[0].id).toBe('id-1');
+
+    const stored: TodoStore = JSON.parse(storage['todos_app_data']);
+    expect(stored.version).toBe(1);
+    expect(stored.todos.length).toBe(1);
+  });
+
+  it('should reject whitespace-only input', () => {
+    createService();
+    service.add('   ');
+    service.add('');
+    service.add('\t');
+    expect(service.todos().length).toBe(0);
+  });
+
+  it('should truncate titles to 250 chars', () => {
+    createService();
+    service.add('a'.repeat(300));
+    expect(service.todos()[0].title.length).toBe(250);
+  });
+
+  it('should toggle a todo', () => {
+    createService();
+    service.add('Test');
+    expect(service.todos()[0].completed).toBe(false);
+    service.toggle('id-1');
+    expect(service.todos()[0].completed).toBe(true);
+    service.toggle('id-1');
+    expect(service.todos()[0].completed).toBe(false);
+  });
+
+  it('should remove a todo and set lastDeleted', () => {
+    createService();
+    service.add('Test');
+    service.remove('id-1');
+    expect(service.todos().length).toBe(0);
+    expect(service.lastDeleted()?.id).toBe('id-1');
+  });
+
+  it('should compute activeCount', () => {
+    createService();
+    service.add('One');
+    service.add('Two');
+    expect(service.activeCount()).toBe(2);
+    service.toggle('id-1');
+    expect(service.activeCount()).toBe(1);
+  });
+
+  it('should load from localStorage on construction', () => {
+    const store: TodoStore = {
+      version: 1,
+      todos: [{ id: 'x', title: 'Persisted', completed: false, createdAt: '2024-01-01T00:00:00Z' }],
+    };
+    storage['todos_app_data'] = JSON.stringify(store);
+    createService();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Persisted');
+  });
+
+  it('should handle corrupted data gracefully', () => {
+    storage['todos_app_data'] = JSON.stringify({ bad: 'data' });
+    createService();
+    expect(service.todos().length).toBe(0);
+    expect(analytics.events.some(e => e.event === 'storage_corrupted')).toBe(true);
+  });
+
+  it('should track analytics events', () => {
+    createService();
+    service.add('Test');
+    service.toggle('id-1');
+    service.remove('id-1');
+    const eventNames = analytics.events.map(e => e.event);
+    expect(eventNames).toContain('todo_created');
+    expect(eventNames).toContain('todo_toggled');
+    expect(eventNames).toContain('todo_deleted');
+  });
+
+  it('should work in-memory when storage unavailable', () => {
+    storageAvailable = false;
+    createService();
+    service.add('In memory');
+    expect(service.todos().length).toBe(1);
+    expect(service.lastWriteSuccess()).toBe(false);
+  });
+
+  it('should set hasEverHadTodos after first add', () => {
+    createService();
+    expect(service.hasEverHadTodos()).toBe(false);
+    service.add('First');
+    expect(service.hasEverHadTodos()).toBe(true);
+  });
+});

--- a/src/app/features/todo/todo-item.component.css
+++ b/src/app/features/todo/todo-item.component.css
@@ -1,0 +1,70 @@
+:host {
+  display: block;
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.todo-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
+  gap: 12px;
+}
+
+.todo-checkbox {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.todo-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.completed .todo-label {
+  text-decoration: line-through;
+  color: #999;
+}
+
+.todo-delete {
+  flex-shrink: 0;
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  color: #ccc;
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.3;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.todo-item:hover .todo-delete,
+.todo-delete:focus {
+  opacity: 1;
+  color: #e74c3c;
+}
+
+.todo-delete:focus {
+  outline: 2px solid #e74c3c;
+  outline-offset: 2px;
+}

--- a/src/app/features/todo/todo-item.component.html
+++ b/src/app/features/todo/todo-item.component.html
@@ -1,0 +1,17 @@
+<div class="todo-item" [class.completed]="todo().completed">
+  <input
+    type="checkbox"
+    [id]="'todo-' + todo().id"
+    [checked]="todo().completed"
+    (change)="toggled.emit(todo().id)"
+    class="todo-checkbox"
+  />
+  <label [for]="'todo-' + todo().id" class="todo-label" [title]="todo().title">
+    {{ todo().title }}
+  </label>
+  <button
+    class="todo-delete"
+    (click)="deleted.emit(todo().id)"
+    [attr.aria-label]="'Delete todo: ' + todo().title"
+  >&times;</button>
+</div>

--- a/src/app/features/todo/todo-item.component.ts
+++ b/src/app/features/todo/todo-item.component.ts
@@ -1,0 +1,14 @@
+import { Component, input, output } from '@angular/core';
+import { Todo } from './todo.model';
+
+@Component({
+  selector: 'app-todo-item',
+  standalone: true,
+  templateUrl: './todo-item.component.html',
+  styleUrl: './todo-item.component.css',
+})
+export class TodoItemComponent {
+  readonly todo = input.required<Todo>();
+  readonly toggled = output<string>();
+  readonly deleted = output<string>();
+}

--- a/src/app/features/todo/todo-list.component.css
+++ b/src/app/features/todo/todo-list.component.css
@@ -1,0 +1,103 @@
+:host {
+  display: flex;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.todo-container {
+  width: 100%;
+  max-width: 560px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.warning-banner {
+  padding: 10px 16px;
+  background: #fff3cd;
+  color: #856404;
+  font-size: 0.875rem;
+  border-bottom: 1px solid #ffc107;
+}
+
+.warning-inline {
+  padding: 6px 16px;
+  color: #856404;
+  font-size: 0.8rem;
+}
+
+.input-area {
+  border-bottom: 1px solid #eee;
+}
+
+.todo-input {
+  width: 100%;
+  padding: 16px;
+  border: none;
+  font-size: 1.1rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.todo-input::placeholder {
+  color: #bbb;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid #eee;
+  gap: 12px;
+}
+
+.items-left {
+  font-size: 0.875rem;
+  color: #888;
+  white-space: nowrap;
+}
+
+.filter-buttons {
+  display: flex;
+  margin-left: auto;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.filter-btn {
+  padding: 6px 14px;
+  border: none;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #666;
+  border-right: 1px solid #ddd;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filter-btn:last-child {
+  border-right: none;
+}
+
+.filter-btn.active {
+  background: #4a90d9;
+  color: #fff;
+}
+
+.filter-btn:focus {
+  outline: 2px solid #4a90d9;
+  outline-offset: -2px;
+}
+
+.empty-state {
+  padding: 32px 16px;
+  text-align: center;
+  color: #aaa;
+  font-size: 0.95rem;
+}
+
+.todo-list {
+  min-height: 60px;
+}

--- a/src/app/features/todo/todo-list.component.html
+++ b/src/app/features/todo/todo-list.component.html
@@ -1,0 +1,53 @@
+<section class="todo-container" aria-label="Todo list">
+  @if (!storage.storageAvailable()) {
+    <div class="warning-banner" role="alert">
+      Your browser doesn't support local storage. Todos won't be saved between sessions.
+    </div>
+  }
+
+  <div class="input-area">
+    <input
+      type="text"
+      class="todo-input"
+      placeholder="What needs to be done?"
+      maxlength="250"
+      [ngModel]="inputValue()"
+      (ngModelChange)="inputValue.set($event)"
+      (keydown.enter)="onSubmit()"
+      #todoInput
+    />
+    @if (!todoService.lastWriteSuccess()) {
+      <div class="warning-inline" role="alert">
+        Storage full — new items may not be saved.
+      </div>
+    }
+  </div>
+
+  <div class="filter-bar">
+    <span class="items-left">{{ itemsLeftText() }}</span>
+    <div class="filter-buttons" role="group" aria-label="Filter todos">
+      @for (f of ['all', 'active', 'completed']; track f) {
+        <button
+          class="filter-btn"
+          [class.active]="filter() === f"
+          [attr.aria-pressed]="filter() === f"
+          (click)="setFilter($any(f))"
+        >{{ f === 'all' ? 'All' : f === 'active' ? 'Active' : 'Completed' }}</button>
+      }
+    </div>
+  </div>
+
+  <div class="todo-list">
+    @for (todo of filteredTodos(); track todo.id) {
+      <app-todo-item
+        [todo]="todo"
+        (toggled)="onToggle($event)"
+        (deleted)="onDelete($event)"
+      />
+    } @empty {
+      @if (emptyStateMessage()) {
+        <div class="empty-state">{{ emptyStateMessage() }}</div>
+      }
+    }
+  </div>
+</section>

--- a/src/app/features/todo/todo-list.component.ts
+++ b/src/app/features/todo/todo-list.component.ts
@@ -1,0 +1,65 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TodoItemComponent } from './todo-item.component';
+import { TodoService } from './todo.service';
+import { StorageAdapter } from '../../core/storage-adapter.service';
+import { AnalyticsService } from '../../core/analytics.service';
+import { TodoFilter } from './todo.model';
+
+@Component({
+  selector: 'app-todo-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TodoItemComponent],
+  templateUrl: './todo-list.component.html',
+  styleUrl: './todo-list.component.css',
+})
+export class TodoListComponent {
+  protected readonly todoService = inject(TodoService);
+  protected readonly storage = inject(StorageAdapter);
+  private readonly analytics = inject(AnalyticsService);
+
+  protected readonly filter = signal<TodoFilter>('all');
+  protected readonly inputValue = signal('');
+
+  protected readonly filteredTodos = computed(() => {
+    const todos = this.todoService.todos();
+    const f = this.filter();
+    if (f === 'active') return todos.filter(t => !t.completed);
+    if (f === 'completed') return todos.filter(t => t.completed);
+    return todos;
+  });
+
+  protected readonly emptyStateMessage = computed(() => {
+    if (this.filteredTodos().length > 0) return '';
+    if (!this.todoService.hasEverHadTodos()) return 'Add your first task above to get started';
+    const f = this.filter();
+    if (f === 'completed') return 'No completed tasks yet';
+    if (f === 'active') return 'Everything is done! \u{1F389}';
+    return '';
+  });
+
+  protected readonly itemsLeftText = computed(() => {
+    const count = this.todoService.activeCount();
+    return count === 1 ? '1 item left' : `${count} items left`;
+  });
+
+  onSubmit(): void {
+    const value = this.inputValue();
+    this.inputValue.set('');
+    this.todoService.add(value);
+  }
+
+  setFilter(f: TodoFilter): void {
+    this.filter.set(f);
+    this.analytics.track('todo_filter_changed', { filter: f });
+  }
+
+  onToggle(id: string): void {
+    this.todoService.toggle(id);
+  }
+
+  onDelete(id: string): void {
+    this.todoService.remove(id);
+  }
+}

--- a/src/app/features/todo/todo.model.ts
+++ b/src/app/features/todo/todo.model.ts
@@ -1,0 +1,34 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: string;
+}
+
+export interface TodoStore {
+  version: number;
+  todos: Todo[];
+}
+
+export type TodoFilter = 'all' | 'active' | 'completed';
+
+export function isTodo(value: unknown): value is Todo {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['id'] === 'string' &&
+    typeof obj['title'] === 'string' &&
+    typeof obj['completed'] === 'boolean' &&
+    typeof obj['createdAt'] === 'string'
+  );
+}
+
+export function isTodoStore(value: unknown): value is TodoStore {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['version'] === 'number' &&
+    Array.isArray(obj['todos']) &&
+    obj['todos'].every(isTodo)
+  );
+}

--- a/src/app/features/todo/todo.service.ts
+++ b/src/app/features/todo/todo.service.ts
@@ -1,0 +1,95 @@
+import { computed, inject, Injectable, InjectionToken, signal } from '@angular/core';
+import { StorageAdapter } from '../../core/storage-adapter.service';
+import { AnalyticsService } from '../../core/analytics.service';
+import { Todo, TodoStore, isTodoStore } from './todo.model';
+
+export const ID_GENERATOR = new InjectionToken<() => string>('IdGenerator', {
+  providedIn: 'root',
+  factory: () => () => crypto.randomUUID(),
+});
+
+const STORAGE_KEY = 'todos_app_data';
+
+@Injectable({ providedIn: 'root' })
+export class TodoService {
+  private readonly storage = inject(StorageAdapter);
+  private readonly analytics = inject(AnalyticsService);
+  private readonly idGenerator = inject(ID_GENERATOR);
+
+  private readonly _todos = signal<Todo[]>(this.loadTodos());
+  private readonly _hasEverHadTodos = signal(false);
+  private readonly _lastWriteSuccess = signal(true);
+
+  readonly todos = this._todos.asReadonly();
+  readonly activeCount = computed(() => this._todos().filter(t => !t.completed).length);
+  readonly hasEverHadTodos = this._hasEverHadTodos.asReadonly();
+  readonly lastWriteSuccess = this._lastWriteSuccess.asReadonly();
+  private readonly _lastDeleted = signal<Todo | null>(null);
+  readonly lastDeleted = this._lastDeleted.asReadonly();
+
+  constructor() {
+    if (this._todos().length > 0) {
+      this._hasEverHadTodos.set(true);
+    }
+  }
+
+  add(title: string): void {
+    const trimmed = title.trim().substring(0, 250);
+    if (!trimmed) return;
+
+    const todo: Todo = {
+      id: this.idGenerator(),
+      title: trimmed,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    this._todos.update(prev => [todo, ...prev]);
+    this._hasEverHadTodos.set(true);
+    this.persist();
+    this.analytics.track('todo_created', { title: trimmed, timestamp: todo.createdAt });
+  }
+
+  toggle(id: string): void {
+    this._todos.update(prev =>
+      prev.map(t => (t.id === id ? { ...t, completed: !t.completed } : t))
+    );
+    this.persist();
+    const toggled = this._todos().find(t => t.id === id);
+    if (toggled) {
+      this.analytics.track('todo_toggled', { id, completed: toggled.completed });
+    }
+  }
+
+  remove(id: string): void {
+    const removed = this._todos().find(t => t.id === id);
+    if (removed) {
+      this._lastDeleted.set(removed);
+    }
+    this._todos.update(prev => prev.filter(t => t.id !== id));
+    this.persist();
+    this.analytics.track('todo_deleted', { id });
+  }
+
+  private persist(): void {
+    const store: TodoStore = { version: 1, todos: this._todos() };
+    const success = this.storage.write(STORAGE_KEY, store);
+    this._lastWriteSuccess.set(success);
+  }
+
+  private loadTodos(): Todo[] {
+    const data = this.storage.read<unknown>(STORAGE_KEY);
+    if (data === null) return [];
+
+    if (isTodoStore(data) && data.version === 1) {
+      return data.todos;
+    }
+
+    // Corrupted or unknown version
+    this.analytics.track('storage_corrupted', {
+      key: STORAGE_KEY,
+      error: 'Invalid or unknown storage schema',
+    });
+    return [];
+  }
+}


### PR DESCRIPTION
## Story
**SAM1-164**: **Hypothesis**

## Acceptance Criteria
- Given the todo input is focused, when user types "Buy milk" and presses Enter, then a new todo "Buy milk" appears in the list, the input is cleared and retains focus, and the todo is persisted to localStorage under the versioned schema { version: 1, todos: [...] }.
- Given the todo input contains only whitespace or is empty, when user presses Enter, then no todo is added, no error is thrown, and input stays focused. Titles are trimmed before evaluation and capped at 250 characters.
- Given an active todo exists, when user clicks its checkbox, then the todo is marked completed with immediate strikethrough and dimmed styling, and localStorage is updated synchronously. Toggling back reverses the styling.
- Given a todo exists, when user clicks the delete button (or presses Enter while the delete button is focused), then the todo is removed from the list and from localStorage.
- Given both active and completed todos exist, when user clicks a filter button (All / Active / Completed), then only matching todos are displayed. If no todos match the active filter, a contextual empty state message is shown (e.g. "No completed tasks yet" or "Everything is done! 🎉"). The items-left counter reflects only active items with correct singular/plural ("1 item left" vs "N items left").
- Given todos exist in the list, when user refreshes the browser, then all todos are restored from localStorage with correct state and the filter resets to "All".
- Given localStorage is unavailable (e.g. private browsing) or quota is exceeded, when the app loads or a write fails, then the feature works in-memory for the current session, a non-blocking inline warning is displayed, and no errors are thrown to the user.
- Given the todo list is rendered, when inspected for accessibility, then checkboxes are real <input type="checkbox"> with associated <label>, delete buttons have aria-label="Delete todo: {title}" and ≥44×44px touch targets, filter buttons use aria-pressed, and all components use standalone: true with zero NgModule declarations.

## Implementation Details
### Architecture


# Technical Architecture Review: Todo Feature

## Data Model

The `Todo` interface at `src/app/features/todo/todo.model.ts` should be defined as follows:

```typescript
export interface Todo {
  id: string;
  title: string;
  completed: boolean;
  createdAt: string; // ISO 8601
}
```

- The `id` field should be generated via `crypto.randomUUID()`, which is available in all modern browsers and avoids pulling in a UUID library. Provide a fallback using `Date.now().toString(36) + Math.random().toString(36).substring(2)` only if you need to support older environments, but Angular 21 already impl

### Developer Notes
**Signals over Observables**
Use Angular signals (`signal`, `computed`, `update`) for all state management in this feature. No RxJS. Every mutation in `TodoService` must produce a new array reference via `this._todos.update(prev => ...)` — never mutate in place, as this won't trigger signal updates.

**Versioned Storage Schema**
Persist todos under localStorage key `todos_app_data` using the wrapper `{ version: 1, todos: Todo[] }`. On load, validate with runtime type guards (`isTodoStore`, `isTodo`). If the version field is missing or data is malformed, discard and initialize empty. Log a `sto

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/core/analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/core/storage-adapter.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/__tests__/todo-item.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/__tests__/todo-list.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/__tests__/todo.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-item.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-item.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-item.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Let's create a basic to-do feature to the app (no backend, just local storage) -->
<!-- bmad:team_id=SAM1 -->