### PR TITLE
feat(SAM1): Create a basic contact form (no backend) [SAM1-176]

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'contact',
+    loadComponent: () =>
+      import('./contact-form/contact-form.component').then(m => m.ContactFormComponent),
+  },
+];

--- a/src/app/contact-form/contact-form.component.css
+++ b/src/app/contact-form/contact-form.component.css
@@ -1,0 +1,120 @@
+.contact-form-wrapper {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+}
+
+.required-legend {
+  font-size: 0.875rem;
+  color: #555;
+  margin-bottom: 1.5rem;
+}
+
+.asterisk {
+  color: #c00;
+  font-weight: bold;
+}
+
+.banner-container {
+  min-height: 3rem;
+}
+
+.success-banner {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  animation: fadeIn 300ms ease-in;
+  outline: none;
+}
+
+.success-banner.fade-out {
+  animation: fadeOut 300ms ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.form-field {
+  margin-bottom: 1.25rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+input:focus,
+textarea:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 1px;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.char-counter {
+  display: block;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.error {
+  display: block;
+  color: #c00;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  word-wrap: break-word;
+}
+
+button {
+  background: #0066cc;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  background: #0052a3;
+}
+
+.helper-text {
+  color: #c00;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}

--- a/src/app/contact-form/contact-form.component.html
+++ b/src/app/contact-form/contact-form.component.html
@@ -1,0 +1,102 @@
+<div class="contact-form-wrapper">
+  <!-- Success Banner Container (fixed height to prevent layout shift) -->
+  <div class="banner-container" aria-live="polite" role="status">
+    @if (bannerVisible) {
+      <div
+        #successBanner
+        class="success-banner"
+        [class.fade-out]="bannerFadingOut"
+        tabindex="-1"
+        (click)="dismissBanner()"
+      >
+        <span aria-hidden="true">&#10003;</span> Thank you! Your message has been sent.
+      </div>
+    }
+  </div>
+
+  <h1>Contact Us</h1>
+  <p class="required-legend"><span class="asterisk" aria-hidden="true">*</span> indicates a required field</p>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <!-- Honeypot -->
+    <input type="text" name="website" tabindex="-1" autocomplete="off" style="display:none">
+
+    <!-- Name -->
+    <div class="form-field">
+      <label for="name">Name <span class="asterisk" aria-hidden="true">*</span></label>
+      <input
+        id="name"
+        type="text"
+        formControlName="name"
+        aria-required="true"
+        [attr.aria-describedby]="shouldShowError('name') ? 'name-error' : null"
+      >
+      @if (shouldShowError('name')) {
+        <span id="name-error" class="error" role="alert">
+          <span aria-hidden="true">&#9888;</span> {{ getErrorMessage('name') }}
+        </span>
+      }
+    </div>
+
+    <!-- Email -->
+    <div class="form-field">
+      <label for="email">Email <span class="asterisk" aria-hidden="true">*</span></label>
+      <input
+        id="email"
+        type="email"
+        formControlName="email"
+        aria-required="true"
+        [attr.aria-describedby]="shouldShowError('email') ? 'email-error' : null"
+      >
+      @if (shouldShowError('email')) {
+        <span id="email-error" class="error" role="alert">
+          <span aria-hidden="true">&#9888;</span> {{ getErrorMessage('email') }}
+        </span>
+      }
+    </div>
+
+    <!-- Subject -->
+    <div class="form-field">
+      <label for="subject">Subject</label>
+      <input
+        id="subject"
+        type="text"
+        formControlName="subject"
+      >
+    </div>
+
+    <!-- Message -->
+    <div class="form-field">
+      <label for="message">Message <span class="asterisk" aria-hidden="true">*</span></label>
+      <textarea
+        id="message"
+        formControlName="message"
+        rows="4"
+        aria-required="true"
+        [attr.aria-describedby]="shouldShowError('message') ? 'message-error' : null"
+      ></textarea>
+      <span class="char-counter">{{ form.controls.message.value.length }} / 10 min</span>
+      @if (shouldShowError('message')) {
+        <span id="message-error" class="error" role="alert">
+          <span aria-hidden="true">&#9888;</span> {{ getErrorMessage('message') }}
+        </span>
+      }
+    </div>
+
+    <!-- Submit -->
+    <button
+      type="submit"
+      [disabled]="form.invalid || form.pristine || isSubmitting"
+    >
+      @if (isSubmitting) {
+        Sending...
+      } @else {
+        Submit
+      }
+    </button>
+
+    @if (form.invalid && form.dirty) {
+      <p class="helper-text">Please complete all required fields</p>
+    }
+  </form>
+</div>

--- a/src/app/contact-form/contact-form.component.spec.ts
+++ b/src/app/contact-form/contact-form.component.spec.ts
@@ -1,0 +1,555 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, Subject } from 'rxjs';
+import { ContactFormComponent } from './contact-form.component';
+import { ContactFormService } from './contact-form.service';
+import { ContactFormPayload } from './contact-form.model';
+
+// Polyfill scrollIntoView for JSDOM
+HTMLElement.prototype.scrollIntoView = vi.fn();
+
+describe('ContactFormComponent', () => {
+  let component: ContactFormComponent;
+  let fixture: ComponentFixture<ContactFormComponent>;
+  let mockService: {
+    submit: ReturnType<typeof vi.fn>;
+    logViewed: ReturnType<typeof vi.fn>;
+    logValidationFailed: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    mockService = {
+      submit: vi.fn().mockReturnValue(of({ status: 'received' })),
+      logViewed: vi.fn(),
+      logValidationFailed: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ContactFormComponent, ReactiveFormsModule],
+      providers: [
+        { provide: ContactFormService, useValue: mockService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContactFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function fillValidForm() {
+    component.form.patchValue({
+      name: 'John Doe',
+      email: 'john@example.com',
+      subject: '',
+      message: 'Hello, this is a test message.',
+    });
+    component.form.markAsDirty();
+    fixture.detectChanges();
+  }
+
+  describe('Form Renders', () => {
+    it('should render all form fields', () => {
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('#name')).toBeTruthy();
+      expect(el.querySelector('#email')).toBeTruthy();
+      expect(el.querySelector('#subject')).toBeTruthy();
+      expect(el.querySelector('#message')).toBeTruthy();
+    });
+
+    it('should have submit button disabled initially', () => {
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should call logViewed on init', () => {
+      expect(mockService.logViewed).toHaveBeenCalled();
+    });
+
+    it('should have required asterisks on Name, Email, Message labels', () => {
+      const labels = fixture.nativeElement.querySelectorAll('label');
+      const labelTexts = Array.from(labels).map((l: any) => l.textContent);
+      expect(labelTexts.some((t: string) => t.includes('Name') && t.includes('*'))).toBe(true);
+      expect(labelTexts.some((t: string) => t.includes('Email') && t.includes('*'))).toBe(true);
+      expect(labelTexts.some((t: string) => t.includes('Message') && t.includes('*'))).toBe(true);
+    });
+
+    it('should NOT have asterisk on Subject label', () => {
+      const labels = fixture.nativeElement.querySelectorAll('label');
+      const subjectLabel = Array.from(labels).find((l: any) => l.textContent.includes('Subject')) as HTMLElement;
+      expect(subjectLabel).toBeTruthy();
+      expect(subjectLabel.querySelector('.asterisk')).toBeFalsy();
+    });
+
+    it('should have aria-required on required fields', () => {
+      expect(fixture.nativeElement.querySelector('#name')?.getAttribute('aria-required')).toBe('true');
+      expect(fixture.nativeElement.querySelector('#email')?.getAttribute('aria-required')).toBe('true');
+      expect(fixture.nativeElement.querySelector('#message')?.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should NOT have aria-required on subject', () => {
+      expect(fixture.nativeElement.querySelector('#subject')?.getAttribute('aria-required')).toBeNull();
+    });
+
+    it('should have a honeypot field', () => {
+      const honeypot = fixture.nativeElement.querySelector('input[name="website"]');
+      expect(honeypot).toBeTruthy();
+      expect(honeypot.getAttribute('tabindex')).toBe('-1');
+      expect(honeypot.style.display).toBe('none');
+    });
+
+    it('should have aria-live on banner container', () => {
+      const container = fixture.nativeElement.querySelector('.banner-container');
+      expect(container.getAttribute('aria-live')).toBe('polite');
+      expect(container.getAttribute('role')).toBe('status');
+    });
+
+    it('should display required-legend text', () => {
+      const legend = fixture.nativeElement.querySelector('.required-legend');
+      expect(legend?.textContent).toContain('indicates a required field');
+    });
+  });
+
+  describe('Valid Submission', () => {
+    it('should call submit with payload including subject key', () => {
+      fillValidForm();
+      component.onSubmit();
+      expect(mockService.submit).toHaveBeenCalledTimes(1);
+      const payload: ContactFormPayload = mockService.submit.mock.calls[0][0];
+      expect(payload.name).toBe('John Doe');
+      expect(payload.email).toBe('john@example.com');
+      expect('subject' in payload).toBe(true);
+      expect(payload.subject).toBe('');
+      expect(payload.message).toBe('Hello, this is a test message.');
+      expect(payload.timestamp).toBeTruthy();
+    });
+
+    it('should include ISO 8601 timestamp in payload', () => {
+      fillValidForm();
+      component.onSubmit();
+      const payload: ContactFormPayload = mockService.submit.mock.calls[0][0];
+      expect(() => new Date(payload.timestamp).toISOString()).not.toThrow();
+    });
+
+    it('should show success banner after submission', () => {
+      fillValidForm();
+      component.onSubmit();
+      fixture.detectChanges();
+      expect(component.bannerVisible).toBe(true);
+      const banner = fixture.nativeElement.querySelector('.success-banner');
+      expect(banner).toBeTruthy();
+      expect(banner.textContent).toContain('Thank you');
+      expect(banner.textContent).toContain('✓');
+    });
+
+    it('should reset form to pristine untouched state', () => {
+      fillValidForm();
+      component.onSubmit();
+      expect(component.form.pristine).toBe(true);
+      expect(component.form.untouched).toBe(true);
+      expect(component.form.value.name).toBe('');
+      expect(component.form.value.email).toBe('');
+      expect(component.form.value.message).toBe('');
+    });
+
+    it('should not show validation errors after reset (no flash)', () => {
+      fillValidForm();
+      component.onSubmit();
+      fixture.detectChanges();
+      const errors = fixture.nativeElement.querySelectorAll('.error');
+      expect(errors.length).toBe(0);
+    });
+
+    it('should trim whitespace from name and message in payload', () => {
+      component.form.patchValue({
+        name: '  John  ',
+        email: 'john@example.com',
+        message: '  Hello world test  ',
+      });
+      component.form.markAsDirty();
+      component.onSubmit();
+      const payload: ContactFormPayload = mockService.submit.mock.calls[0][0];
+      expect(payload.name).toBe('John');
+      expect(payload.message).toBe('Hello world test');
+    });
+
+    it('should submit with non-empty subject', () => {
+      component.form.patchValue({
+        name: 'John',
+        email: 'john@example.com',
+        subject: 'Inquiry',
+        message: 'Hello world test',
+      });
+      component.form.markAsDirty();
+      component.onSubmit();
+      const payload: ContactFormPayload = mockService.submit.mock.calls[0][0];
+      expect(payload.subject).toBe('Inquiry');
+    });
+  });
+
+  describe('Required Field Validation', () => {
+    it('should show error on blur of empty required field', () => {
+      component.form.controls.name.markAsTouched();
+      fixture.detectChanges();
+      expect(component.shouldShowError('name')).toBe(true);
+      expect(component.getErrorMessage('name')).toBe('Name is required');
+    });
+
+    it('should show error for empty email on touch', () => {
+      component.form.controls.email.markAsTouched();
+      fixture.detectChanges();
+      expect(component.shouldShowError('email')).toBe(true);
+      expect(component.getErrorMessage('email')).toBe('Email is required');
+    });
+
+    it('should show error for empty message on touch', () => {
+      component.form.controls.message.markAsTouched();
+      fixture.detectChanges();
+      expect(component.shouldShowError('message')).toBe(true);
+      expect(component.getErrorMessage('message')).toBe('Message is required');
+    });
+
+    it('should show all errors and call logValidationFailed on invalid submit', () => {
+      component.form.markAsDirty();
+      component.onSubmit();
+      fixture.detectChanges();
+      expect(mockService.logValidationFailed).toHaveBeenCalled();
+      const invalidFields: string[] = mockService.logValidationFailed.mock.calls[0][0];
+      expect(invalidFields).toContain('name');
+      expect(invalidFields).toContain('email');
+      expect(invalidFields).toContain('message');
+      expect(invalidFields).not.toContain('subject');
+    });
+
+    it('should have aria-describedby on invalid fields after submit', () => {
+      component.form.markAsDirty();
+      component.onSubmit();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#name')?.getAttribute('aria-describedby')).toBe('name-error');
+      expect(fixture.nativeElement.querySelector('#email')?.getAttribute('aria-describedby')).toBe('email-error');
+      expect(fixture.nativeElement.querySelector('#message')?.getAttribute('aria-describedby')).toBe('message-error');
+    });
+
+    it('should render error spans with unique ids linked via aria-describedby', () => {
+      component.form.markAsDirty();
+      component.onSubmit();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#name-error')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('#email-error')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('#message-error')).toBeTruthy();
+    });
+
+    it('should render warning icons in error messages', () => {
+      component.form.markAsDirty();
+      component.onSubmit();
+      fixture.detectChanges();
+      const errors = fixture.nativeElement.querySelectorAll('.error');
+      errors.forEach((err: HTMLElement) => {
+        expect(err.textContent).toContain('⚠');
+      });
+    });
+
+    it('should focus and scrollIntoView first invalid field on invalid submit', () => {
+      component.form.markAsDirty();
+      const nameInput = fixture.nativeElement.querySelector('#name') as HTMLElement;
+      const focusSpy = vi.spyOn(nameInput, 'focus');
+      component.onSubmit();
+      expect(nameInput.scrollIntoView).toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('should not call submit service on invalid form', () => {
+      component.onSubmit();
+      expect(mockService.submit).not.toHaveBeenCalled();
+    });
+
+    it('should not show errors for untouched fields before submit', () => {
+      fixture.detectChanges();
+      expect(component.shouldShowError('name')).toBe(false);
+      expect(component.shouldShowError('email')).toBe(false);
+      expect(component.shouldShowError('message')).toBe(false);
+    });
+
+    it('should clear error when field becomes valid after touch', () => {
+      component.form.controls.name.markAsTouched();
+      fixture.detectChanges();
+      expect(component.shouldShowError('name')).toBe(true);
+
+      component.form.controls.name.setValue('Jo');
+      fixture.detectChanges();
+      expect(component.shouldShowError('name')).toBe(false);
+    });
+  });
+
+  describe('Email Format Validation', () => {
+    it('should reject email without dot after @', () => {
+      component.form.controls.email.setValue('foo@bar');
+      component.form.controls.email.markAsTouched();
+      fixture.detectChanges();
+      expect(component.form.controls.email.invalid).toBe(true);
+      expect(component.getErrorMessage('email')).toBe('Please enter a valid email');
+    });
+
+    it('should accept valid email', () => {
+      component.form.controls.email.setValue('foo@bar.com');
+      expect(component.form.controls.email.valid).toBe(true);
+    });
+
+    it('should reject email like user@', () => {
+      component.form.controls.email.setValue('user@');
+      component.form.controls.email.markAsTouched();
+      expect(component.form.controls.email.invalid).toBe(true);
+    });
+
+    it('should reject email like @domain.com', () => {
+      component.form.controls.email.setValue('@domain.com');
+      component.form.controls.email.markAsTouched();
+      expect(component.form.controls.email.invalid).toBe(true);
+    });
+
+    it('should reject email with spaces', () => {
+      component.form.controls.email.setValue('user @bar.com');
+      component.form.controls.email.markAsTouched();
+      expect(component.form.controls.email.invalid).toBe(true);
+    });
+  });
+
+  describe('Whitespace-Only Input Rejected', () => {
+    it('should treat whitespace-only name as invalid', () => {
+      component.form.controls.name.setValue('   ');
+      component.form.controls.name.markAsTouched();
+      fixture.detectChanges();
+      expect(component.form.controls.name.invalid).toBe(true);
+      expect(component.getErrorMessage('name')).toBe('Name must be at least 2 characters');
+    });
+
+    it('should treat whitespace-only message as invalid', () => {
+      component.form.controls.message.setValue('     ');
+      component.form.controls.message.markAsTouched();
+      fixture.detectChanges();
+      expect(component.form.controls.message.invalid).toBe(true);
+      expect(component.getErrorMessage('message')).toBe('Message must be at least 10 characters');
+    });
+
+    it('should treat single char name as invalid (min 2)', () => {
+      component.form.controls.name.setValue('A');
+      component.form.controls.name.markAsTouched();
+      expect(component.form.controls.name.invalid).toBe(true);
+    });
+
+    it('should treat 9-char message as invalid (min 10)', () => {
+      component.form.controls.message.setValue('123456789');
+      component.form.controls.message.markAsTouched();
+      expect(component.form.controls.message.invalid).toBe(true);
+    });
+
+    it('should accept exactly 2-char name', () => {
+      component.form.controls.name.setValue('Jo');
+      expect(component.form.controls.name.valid).toBe(true);
+    });
+
+    it('should accept exactly 10-char message', () => {
+      component.form.controls.message.setValue('1234567890');
+      expect(component.form.controls.message.valid).toBe(true);
+    });
+  });
+
+  describe('Double-Submit Prevention', () => {
+    it('should only submit once on rapid double call', () => {
+      const subject = new Subject<{ status: string }>();
+      mockService.submit.mockReturnValue(subject.asObservable());
+      fillValidForm();
+      component.onSubmit();
+      component.onSubmit();
+      expect(mockService.submit).toHaveBeenCalledTimes(1);
+      subject.next({ status: 'received' });
+      subject.complete();
+    });
+
+    it('should set isSubmitting during submission', () => {
+      // Use a non-completing observable to test mid-flight state
+      // But since of() completes synchronously, isSubmitting resets immediately
+      // So we test the guard instead
+      fillValidForm();
+      component.isSubmitting = true;
+      component.onSubmit();
+      expect(mockService.submit).not.toHaveBeenCalled();
+    });
+
+    it('should have submit button disabled while submitting', () => {
+      fillValidForm();
+      // isSubmitting is set and cleared synchronously with of(), so check via binding logic
+      expect(component.form.invalid || component.form.pristine || component.isSubmitting).toBe(false);
+      component.isSubmitting = true;
+      expect(component.form.invalid || component.form.pristine || component.isSubmitting).toBe(true);
+    });
+  });
+
+  describe('Banner Auto-Dismiss', () => {
+    it('should dismiss banner on click', () => {
+      fillValidForm();
+      component.onSubmit();
+      fixture.detectChanges();
+      expect(component.bannerVisible).toBe(true);
+      component.dismissBanner();
+      expect(component.bannerFadingOut).toBe(true);
+    });
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should auto-dismiss after 5 seconds', () => {
+        fillValidForm();
+        component.onSubmit();
+        expect(component.bannerVisible).toBe(true);
+        vi.advanceTimersByTime(5000);
+        expect(component.bannerFadingOut).toBe(true);
+        vi.advanceTimersByTime(300);
+        expect(component.bannerVisible).toBe(false);
+      });
+    });
+
+    it('should not error if dismissBanner called when banner not visible', () => {
+      expect(component.bannerVisible).toBe(false);
+      expect(() => component.dismissBanner()).not.toThrow();
+    });
+
+    it('should show banner with checkmark icon', () => {
+      fillValidForm();
+      component.onSubmit();
+      fixture.detectChanges();
+      const banner = fixture.nativeElement.querySelector('.success-banner');
+      expect(banner.textContent).toContain('✓');
+    });
+  });
+
+  describe('Character Counter', () => {
+    it('should display message character count', () => {
+      component.form.controls.message.setValue('Hello');
+      fixture.detectChanges();
+      const counter = fixture.nativeElement.querySelector('.char-counter');
+      expect(counter.textContent).toContain('5 / 10 min');
+    });
+
+    it('should show 0 initially', () => {
+      fixture.detectChanges();
+      const counter = fixture.nativeElement.querySelector('.char-counter');
+      expect(counter.textContent).toContain('0 / 10 min');
+    });
+  });
+
+  describe('Helper Text', () => {
+    it('should show helper text when form is dirty and invalid', () => {
+      component.form.controls.name.setValue('a');
+      component.form.markAsDirty();
+      fixture.detectChanges();
+      const helper = fixture.nativeElement.querySelector('.helper-text');
+      expect(helper?.textContent).toContain('Please complete all required fields');
+    });
+
+    it('should hide helper text when form is valid', () => {
+      fillValidForm();
+      fixture.detectChanges();
+      const helper = fixture.nativeElement.querySelector('.helper-text');
+      expect(helper).toBeFalsy();
+    });
+
+    it('should not show helper text when form is pristine', () => {
+      fixture.detectChanges();
+      const helper = fixture.nativeElement.querySelector('.helper-text');
+      expect(helper).toBeFalsy();
+    });
+  });
+
+  describe('Submit button state', () => {
+    it('should be disabled when form is pristine', () => {
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should be disabled when form is invalid and dirty', () => {
+      component.form.controls.name.setValue('a');
+      component.form.markAsDirty();
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should be enabled when form is valid and dirty', () => {
+      fillValidForm();
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+  });
+});
+
+describe('ContactFormService', () => {
+  let service: ContactFormService;
+
+  beforeEach(() => {
+    service = new ContactFormService();
+    vi.restoreAllMocks();
+  });
+
+  it('should return received status on submit', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const payload: ContactFormPayload = {
+      name: 'Test',
+      email: 'test@test.com',
+      subject: '',
+      message: 'Test message here',
+      timestamp: new Date().toISOString(),
+    };
+    let result: { status: string } | undefined;
+    service.submit(payload).subscribe((r) => {
+      result = r;
+    });
+    expect(result?.status).toBe('received');
+    spy.mockRestore();
+  });
+
+  it('should log viewed event', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    service.logViewed();
+    expect(spy).toHaveBeenCalled();
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(logged.event).toBe('contact_form_viewed');
+    expect(logged.route).toBe('/contact');
+    expect(logged.timestamp).toBeTruthy();
+    spy.mockRestore();
+  });
+
+  it('should log validation failed with fields', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    service.logValidationFailed(['name', 'email']);
+    expect(spy).toHaveBeenCalled();
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(logged.event).toBe('contact_form_validation_failed');
+    expect(logged.invalid_fields).toEqual(['name', 'email']);
+    spy.mockRestore();
+  });
+
+  it('should log submitted payload', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const payload: ContactFormPayload = {
+      name: 'Test',
+      email: 'test@test.com',
+      subject: '',
+      message: 'Hello world!',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    };
+    service.submit(payload);
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(logged.event).toBe('contact_form_submitted');
+    expect(logged.name).toBe('Test');
+    expect(logged.email).toBe('test@test.com');
+    expect(logged.subject).toBe('');
+    expect(logged.message).toBe('Hello world!');
+    spy.mockRestore();
+  });
+});

--- a/src/app/contact-form/contact-form.component.ts
+++ b/src/app/contact-form/contact-form.component.ts
@@ -1,0 +1,162 @@
+import {
+  Component,
+  DestroyRef,
+  ElementRef,
+  OnInit,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import {
+  AbstractControl,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subscription, timer } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+
+import { ContactFormPayload } from './contact-form.model';
+import { ContactFormService } from './contact-form.service';
+
+function trimmedMinLength(min: number) {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const trimmed = (control.value as string || '').trim();
+    return trimmed.length < min ? { minlength: { requiredLength: min, actualLength: trimmed.length } } : null;
+  };
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-contact-form',
+  imports: [ReactiveFormsModule],
+  templateUrl: './contact-form.component.html',
+  styleUrls: ['./contact-form.component.css'],
+})
+export class ContactFormComponent implements OnInit {
+  private fb = inject(NonNullableFormBuilder);
+  private contactService = inject(ContactFormService);
+  private destroyRef = inject(DestroyRef);
+  private el = inject(ElementRef);
+
+  @ViewChild('successBanner') successBannerRef!: ElementRef<HTMLDivElement>;
+
+  form = this.fb.group({
+    name: ['', [Validators.required, trimmedMinLength(2)]],
+    email: ['', [Validators.required, Validators.email, Validators.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)]],
+    subject: [''],
+    message: ['', [Validators.required, trimmedMinLength(10)]],
+  });
+
+  isSubmitting = false;
+  bannerVisible = false;
+  bannerFadingOut = false;
+  formSubmitted = false;
+
+  private readonly initialValues = { name: '', email: '', subject: '', message: '' };
+  private bannerTimerSub: Subscription | null = null;
+
+  ngOnInit(): void {
+    this.contactService.logViewed();
+  }
+
+  // TODO: ngOnDestroy — add contact_form_abandoned tracking event
+
+  shouldShowError(controlName: string): boolean {
+    const control = this.form.get(controlName);
+    if (!control) return false;
+    return control.invalid && (control.touched || this.formSubmitted);
+  }
+
+  getErrorMessage(controlName: string): string {
+    const control = this.form.get(controlName);
+    if (!control) return '';
+    if (control.hasError('required')) {
+      return `${this.capitalize(controlName)} is required`;
+    }
+    if (control.hasError('minlength')) {
+      const err = control.getError('minlength');
+      return `${this.capitalize(controlName)} must be at least ${err.requiredLength} characters`;
+    }
+    if (control.hasError('email') || control.hasError('pattern')) {
+      return 'Please enter a valid email';
+    }
+    return '';
+  }
+
+  onSubmit(): void {
+    if (this.isSubmitting) return;
+
+    if (this.form.invalid) {
+      this.formSubmitted = true;
+      this.form.markAllAsTouched();
+
+      const invalidFields = Object.keys(this.form.controls).filter(
+        (key) => this.form.get(key)?.invalid
+      );
+      this.contactService.logValidationFailed(invalidFields);
+
+      // Focus and scroll to first invalid field
+      const firstInvalid = this.el.nativeElement.querySelector(
+        'input.ng-invalid, textarea.ng-invalid'
+      ) as HTMLElement | null;
+      if (firstInvalid) {
+        firstInvalid.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        firstInvalid.focus();
+      }
+      return;
+    }
+
+    this.isSubmitting = true;
+    const payload: ContactFormPayload = {
+      name: this.form.value.name!.trim(),
+      email: this.form.value.email!.trim(),
+      subject: this.form.value.subject ?? '',
+      message: this.form.value.message!.trim(),
+      timestamp: new Date().toISOString(),
+    };
+
+    this.contactService.submit(payload).pipe(
+      finalize(() => {
+        this.isSubmitting = false;
+      })
+    ).subscribe({
+      next: () => {
+        this.showBanner();
+        this.form.reset(this.initialValues);
+        this.form.markAsPristine();
+        this.form.markAsUntouched();
+        this.formSubmitted = false;
+      },
+    });
+  }
+
+  showBanner(): void {
+    this.bannerTimerSub?.unsubscribe();
+    this.bannerVisible = true;
+    this.bannerFadingOut = false;
+    // Focus the banner for screen reader announcement
+    setTimeout(() => {
+      this.successBannerRef?.nativeElement?.focus();
+    });
+    this.bannerTimerSub = timer(5000)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.dismissBanner());
+  }
+
+  dismissBanner(): void {
+    if (!this.bannerVisible) return;
+    this.bannerFadingOut = true;
+    timer(300)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.bannerVisible = false;
+        this.bannerFadingOut = false;
+      });
+  }
+
+  private capitalize(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+}

--- a/src/app/contact-form/contact-form.model.ts
+++ b/src/app/contact-form/contact-form.model.ts
@@ -1,0 +1,7 @@
+export interface ContactFormPayload {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  timestamp: string; // ISO 8601
+}

--- a/src/app/contact-form/contact-form.service.ts
+++ b/src/app/contact-form/contact-form.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { ContactFormPayload } from './contact-form.model';
+
+@Injectable({ providedIn: 'root' })
+export class ContactFormService {
+  submit(payload: ContactFormPayload): Observable<{ status: string }> {
+    console.log(JSON.stringify({ event: 'contact_form_submitted', ...payload }));
+    return of({ status: 'received' });
+  }
+
+  logViewed(): void {
+    console.log(JSON.stringify({
+      event: 'contact_form_viewed',
+      route: '/contact',
+      timestamp: new Date().toISOString(),
+    }));
+  }
+
+  logValidationFailed(invalidFields: string[]): void {
+    console.log(JSON.stringify({
+      event: 'contact_form_validation_failed',
+      invalid_fields: invalidFields,
+      timestamp: new Date().toISOString(),
+    }));
+  }
+}


### PR DESCRIPTION
## ⚠️ Pipeline Failed

**Reason:** Pipeline failed after 2 loop(s). Tests are FAILING.

### Test Failures
```
Test failed (`npx ng test --watch=false`):
[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                            [2m | [22m[1mNames[22m                                       [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                                [2m | [22m[2mspec-app-app[22m                                [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mspec-app-contact-form-contact-form.component.js[39m[2m | [22m[2mspec-app-contact-form-contact-form.component[22m[2m | [22m [36m42.78 kB[39m[2m | [22m
[32mchunk-SHTMZ5XJ.js[39m                              [2m | [22m[2m-[22m                                           [2m | [22m  [36m4.57 kB[39m[2m | [22m
[32minit-testbed.js[39m                                [2m | [22m[2minit-testbed[22m                                [2m | [22m  [36m1.21 kB[39m[2m | [22m
[32mvitest-mock-patch.js[39m                           [2m | [22m[2mvitest-mock-patch[22m                           [2m | [22m[36m481 bytes[39m[2m | [22m
[32mstyles.css[39m                                     [2m | [22m[2mstyles[22m                                      [2m | [22m [36m56 bytes[39m[2m | [22m

[1m [22m                                              [2m | [22m[1mInitial total[22m                               [2m | [22m [1m96.34 kB[22m

Application bundle generation complete. [3.929 seconds] - 2026-03-16T13:55:26.857Z


[1m[46m RUN [49m[2
… (truncated)
```

### Diagnostic
Pipeline exhausted after 2 review loop(s).

### Test Failures
```
Test failed (`npx ng test --watch=false`):
[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                            [2m | [22m[1mNames[22m                                       [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                                [2m | [22m[2mspec-app-app[22m                                [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mspec-app-contact-form-contact-form.component.js[39m[2m | [22m[2mspec-app-contact-form-contact-form.component[22m[2m | [22m [36m42.78 kB[39m[2m | [22m
[32mchunk-SHTMZ5XJ.js[39m                              [2m | [22m[2m-[22m                                           [2m | [22m  [36m4.57 kB[39m[2m | [22m
[32minit-testbed.js[39m                                [2m | [22m[2minit-testbed[22m                                [2m | [22m  [36m1.21 kB[39m[2m | [22m
[32mvitest-mock-patch.js[39m                           [2m | [22m[2mvitest-mock-patch[22m                           [2m | [22m[36m481 bytes[39m[2m | [22m
[32mstyles.css[39m                                     [2m | [22m[2mstyles[22m                                      [2m | [22m [36m56 bytes[39m[2m | [22m

[1m [22m                                              [2m | [22m[1mInitial total[22m                               [2m | [22m [1m96.34 kB[22m

Application bundle generation complete. [3.929 seconds] - 2026-03-16T13:55:26.857Z


[1m[46m RUN [49m[2
… (truncated)
```

### Recommended Next Steps
- Review the issues above and provide `--guidance` on the next run
- Re-run with the same `branch` input to continue from this code state

### How to Continue

**Option 1:** Comment on this PR:
`/bmad retry Your guidance here`

**Option 2:** Manual dispatch:
```
gh workflow run bmad-start-run.yml \
  -f target_repo="diegosramirez/my-test-app" \
  -f branch="bmad/sam1/SAM1-176-create-a-basic-contact-form-no-backend" \
  -f prompt="Create a basic contact form (no backend)" \
  -f team_id="SAM1" \
  -f skip_check_epic_state=true \
  -f skip_create_or_correct_epic=true \
  -f skip_create_story_tasks=true \
  -f skip_party_mode_refinement=true \
  -f extra_flags="--story-key SAM1-176 --retry"
```

---
## Story
**SAM1-176**: **Hypothesis**

## Acceptance Criteria
- Given a visitor navigates to /contact, the contact form renders with Name, Email, Subject, Message fields, required asterisk indicators on Name/Email/Message, a disabled Submit button, and contact_form_viewed is logged to console via ContactFormService
- Given all required fields contain valid data and the user clicks Submit, ContactFormService.submit() is called with a ContactFormPayload (including subject key even if empty), a success banner with checkmark icon and aria-live=polite appears and receives focus, and the form resets to pristine empty state with no flash of validation errors
- Given the user leaves Name, Email, or Message empty and blurs the field or clicks Submit, an inline error with warning icon appears below each invalid field linked via aria-describedby, and on submit-click focus scrolls to the first invalid field
- Given the user enters an email without a dot after the @ symbol (e.g. foo@bar), the error 'Please enter a valid email' is displayed on blur
- Given the user enters only whitespace characters in Name or Message, the field is treated as invalid and the appropriate minimum-length error is displayed
- Given the user rapidly double-clicks Submit on a valid form, only one payload is logged and only one success banner appears due to the isSubmitting guard
- Given the success banner is visible, it auto-dismisses after 5 seconds with a 300ms fade-out or dismisses immediately on click; navigating away before dismissal causes no timer leak or runtime error
- Given viewports of 320px, 768px, and 1024px, the form is usable, error messages do not overflow, color contrast meets WCAG AA 4.5:1, and all ARIA attributes (aria-describedby, aria-live, aria-required) are present and functional

## Implementation Details
### Architecture


# Technical Architecture Review: Contact Form Component

## Data Model Changes Needed

No persistent data model or database changes are required. The form payload is ephemeral and console-only at this stage.

Define a TypeScript interface to establish the UI contract for future API integration. Place it in `src/app/contact-form/contact-form.model.ts`:

```typescript
export interface ContactFormPayload {
  name: string;
  email: string;
  subject: string;
  message: string;
  timestamp: string; // ISO 8601
}
```

This interface serves as the integration seam. When the backend materializes, th

### Developer Notes
**File Structure**
- `src/app/contact-form/contact-form.model.ts` — `ContactFormPayload` interface: `name`, `email`, `subject`, `message`, `timestamp` (ISO 8601)
- `src/app/contact-form/contact-form.service.ts` — `@Injectable({ providedIn: 'root' })` with `submit()`, `logViewed()`, `logValidationFailed()`. Returns `Observable<{ status: string }>` from `submit()` for future HTTP swap.
- `src/app/contact-form/contact-form.component.ts` — Standalone, imports only `ReactiveFormsModule`. Uses `NonNullableFormBuilder` for typed form group.
- `src/app/contact-form/contact-form.component.html` — Templ

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/contact-form/contact-form.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
Pipeline failed with 0 unresolved issue(s) after 2 review loop(s).

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Create a basic contact form (no backend) -->
<!-- bmad:team_id=SAM1 -->