### PR TITLE
feat(SAM1): Create a notes taking feature for the app (no backend) [SAM1-188]

### DIFF
--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,36 @@
+import { routes } from './app.routes';
+
+describe('App Routes', () => {
+  it('should have notes list route', () => {
+    const notesRoute = routes.find(r => r.path === 'notes');
+    expect(notesRoute).toBeTruthy();
+  });
+
+  it('should have notes/new route', () => {
+    const newRoute = routes.find(r => r.path === 'notes/new');
+    expect(newRoute).toBeTruthy();
+  });
+
+  it('should have notes/:id/edit route', () => {
+    const editRoute = routes.find(r => r.path === 'notes/:id/edit');
+    expect(editRoute).toBeTruthy();
+  });
+
+  it('should redirect empty path to notes', () => {
+    const defaultRoute = routes.find(r => r.path === '');
+    expect(defaultRoute).toBeTruthy();
+    expect(defaultRoute!.redirectTo).toBe('notes');
+    expect(defaultRoute!.pathMatch).toBe('full');
+  });
+
+  it('should have notes/new before notes/:id/edit to prevent "new" matching as :id', () => {
+    const newIndex = routes.findIndex(r => r.path === 'notes/new');
+    const editIndex = routes.findIndex(r => r.path === 'notes/:id/edit');
+    expect(newIndex).toBeLessThan(editIndex);
+  });
+
+  it('should use standalone components (no loadChildren or loadComponent lazy)', () => {
+    const componentRoutes = routes.filter(r => r.component);
+    expect(componentRoutes.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
+import { NotesListComponent } from './notes/notes-list.component';
+import { NoteEditorComponent } from './notes/note-editor.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'notes', component: NotesListComponent },
+  { path: 'notes/new', component: NoteEditorComponent },
+  { path: 'notes/:id/edit', component: NoteEditorComponent },
+  { path: '', redirectTo: 'notes', pathMatch: 'full' },
+];

--- a/src/app/notes/note-editor.component.spec.ts
+++ b/src/app/notes/note-editor.component.spec.ts
@@ -1,0 +1,245 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoteEditorComponent } from './note-editor.component';
+import { NotesService } from './notes.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { Note } from './note.model';
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: overrides.id ?? 'note-1',
+    title: overrides.title ?? 'Existing Title',
+    body: overrides.body ?? 'Existing Body',
+    createdAt: overrides.createdAt ?? '2024-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2024-01-02T00:00:00.000Z',
+  };
+}
+
+describe('NoteEditorComponent', () => {
+  let fixture: ComponentFixture<NoteEditorComponent>;
+  let component: NoteEditorComponent;
+  let mockService: any;
+  let router: Router;
+
+  function setup(params: Record<string, string | null> = {}, existingNote?: Note) {
+    mockService = {
+      getById: vi.fn((id: string) => existingNote ?? null),
+      create: vi.fn((title: string, body: string) => makeNote({ title, body, id: 'new-id' })),
+      update: vi.fn((id: string, title: string, body: string) => existingNote ? { ...existingNote, title, body, updatedAt: new Date().toISOString() } : null),
+    };
+
+    const mockRoute = {
+      snapshot: {
+        paramMap: {
+          get: (key: string) => params[key] ?? null,
+        },
+      },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [NoteEditorComponent],
+      providers: [
+        provideRouter([]),
+        { provide: NotesService, useValue: mockService },
+        { provide: ActivatedRoute, useValue: mockRoute },
+      ],
+    });
+
+    fixture = TestBed.createComponent(NoteEditorComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    fixture.detectChanges();
+  }
+
+  describe('Create Mode', () => {
+    it('should be in create mode with no id param', () => {
+      setup({});
+      expect(component.isEditMode).toBe(false);
+      expect(fixture.nativeElement.querySelector('h1')?.textContent).toContain('New Note');
+    });
+
+    it('should have empty title and body', () => {
+      setup({});
+      expect(component.title).toBe('');
+      expect(component.body).toBe('');
+    });
+
+    it('should call service.create on save', () => {
+      setup({});
+      component.title = 'New Title';
+      component.body = 'New Body';
+      component.onSave();
+      expect(mockService.create).toHaveBeenCalledWith('New Title', 'New Body');
+    });
+
+    it('should navigate to /notes with saved=true after successful create', () => {
+      setup({});
+      component.title = 'New Title';
+      component.body = 'Body';
+      component.onSave();
+      expect(router.navigate).toHaveBeenCalledWith(['/notes'], { queryParams: { saved: 'true' } });
+    });
+  });
+
+  describe('Edit Mode', () => {
+    it('should be in edit mode with id param', () => {
+      const note = makeNote({ id: 'edit-1', title: 'Edit Me', body: 'Edit body' });
+      setup({ id: 'edit-1' }, note);
+      expect(component.isEditMode).toBe(true);
+      expect(component.title).toBe('Edit Me');
+      expect(component.body).toBe('Edit body');
+      expect(fixture.nativeElement.querySelector('h1')?.textContent).toContain('Edit Note');
+    });
+
+    it('should call service.update on save in edit mode', () => {
+      const note = makeNote({ id: 'edit-1' });
+      setup({ id: 'edit-1' }, note);
+      component.title = 'Updated';
+      component.body = 'Updated body';
+      component.onSave();
+      expect(mockService.update).toHaveBeenCalledWith('edit-1', 'Updated', 'Updated body');
+    });
+
+    it('should redirect to /notes if note not found', () => {
+      setup({ id: 'missing-id' }, undefined);
+      expect(router.navigate).toHaveBeenCalledWith(['/notes']);
+    });
+  });
+
+  describe('Validation', () => {
+    it('should disable save when title is empty', () => {
+      setup({});
+      fixture.detectChanges();
+      const saveBtn = fixture.nativeElement.querySelector('.btn-save') as HTMLButtonElement;
+      expect(saveBtn.disabled).toBe(true);
+    });
+
+    it('should enable save when title has content', () => {
+      setup({});
+      component.title = 'Something';
+      fixture.detectChanges();
+      const saveBtn = fixture.nativeElement.querySelector('.btn-save') as HTMLButtonElement;
+      expect(saveBtn.disabled).toBe(false);
+    });
+
+    it('should show title error when saving with empty title', () => {
+      setup({});
+      component.title = '   ';
+      component.onSave();
+      fixture.detectChanges();
+      expect(component.showTitleError).toBe(true);
+      expect(fixture.nativeElement.querySelector('#title-error')?.textContent).toContain('Title is required');
+    });
+
+    it('should not call service when title is empty', () => {
+      setup({});
+      component.title = '';
+      component.onSave();
+      expect(mockService.create).not.toHaveBeenCalled();
+    });
+
+    it('should clear title error on input when title is non-empty', () => {
+      setup({});
+      component.showTitleError = true;
+      component.title = 'Valid';
+      component.onInput();
+      expect(component.showTitleError).toBe(false);
+    });
+
+    it('should have aria-describedby when title error is shown', () => {
+      setup({});
+      component.showTitleError = true;
+      fixture.detectChanges();
+      const input = fixture.nativeElement.querySelector('#note-title');
+      expect(input?.getAttribute('aria-describedby')).toBe('title-error');
+    });
+  });
+
+  describe('Double-click guard', () => {
+    it('should set isSaving on save', () => {
+      setup({});
+      component.title = 'Title';
+      component.onSave();
+      expect(component.isSaving).toBe(true);
+    });
+
+    it('should disable save button when isSaving', () => {
+      setup({});
+      component.title = 'Title';
+      component.isSaving = true;
+      fixture.detectChanges();
+      const saveBtn = fixture.nativeElement.querySelector('.btn-save') as HTMLButtonElement;
+      expect(saveBtn.disabled).toBe(true);
+    });
+
+    it('should re-enable isSaving on failed save', () => {
+      setup({});
+      mockService.create.mockReturnValue(null);
+      component.title = 'Title';
+      component.onSave();
+      expect(component.isSaving).toBe(false);
+    });
+  });
+
+  describe('Cancel / Discard', () => {
+    it('should show "Back" when form is clean', () => {
+      setup({});
+      fixture.detectChanges();
+      const cancelBtn = fixture.nativeElement.querySelector('.btn-cancel');
+      expect(cancelBtn?.textContent?.trim()).toBe('Back');
+    });
+
+    it('should show "Discard changes" when form is dirty', () => {
+      setup({});
+      component.isDirty = true;
+      fixture.detectChanges();
+      const cancelBtn = fixture.nativeElement.querySelector('.btn-cancel');
+      expect(cancelBtn?.textContent?.trim()).toBe('Discard changes');
+    });
+
+    it('should navigate directly when clean', () => {
+      setup({});
+      component.isDirty = false;
+      component.onCancel();
+      expect(router.navigate).toHaveBeenCalledWith(['/notes']);
+    });
+
+    it('should show discard dialog when dirty', () => {
+      setup({});
+      component.isDirty = true;
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      component.onCancel();
+      expect(dialog.showModal).toHaveBeenCalled();
+    });
+
+    it('should navigate on discardAndNavigate', () => {
+      setup({});
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.close = vi.fn();
+      component.discardAndNavigate();
+      expect(router.navigate).toHaveBeenCalledWith(['/notes']);
+      expect(component.isDirty).toBe(false);
+    });
+  });
+
+  describe('Discard Dialog Accessibility', () => {
+    it('should have role="dialog" and aria-modal on discard dialog', () => {
+      setup({});
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog?.getAttribute('role')).toBe('dialog');
+      expect(dialog?.getAttribute('aria-modal')).toBe('true');
+      expect(dialog?.getAttribute('aria-labelledby')).toBe('discard-dialog-title');
+    });
+  });
+
+  describe('onInput', () => {
+    it('should set isDirty to true', () => {
+      setup({});
+      expect(component.isDirty).toBe(false);
+      component.onInput();
+      expect(component.isDirty).toBe(true);
+    });
+  });
+});

--- a/src/app/notes/note-editor.component.ts
+++ b/src/app/notes/note-editor.component.ts
@@ -1,0 +1,293 @@
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, ActivatedRoute, Router } from '@angular/router';
+import { NotesService } from './notes.service';
+
+@Component({
+  selector: 'app-note-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  template: `
+    <div class="editor-container">
+      <header class="editor-header">
+        <h1>{{ isEditMode ? 'Edit Note' : 'New Note' }}</h1>
+      </header>
+
+      <div class="form-body">
+        <div class="field">
+          <label for="note-title" class="field-label">Title</label>
+          <input
+            id="note-title"
+            type="text"
+            class="input-title"
+            placeholder="Note title"
+            [(ngModel)]="title"
+            (input)="onInput()"
+            [attr.aria-describedby]="showTitleError ? 'title-error' : null"
+            [class.input-error]="showTitleError"
+          />
+          <p id="title-error" class="error-text" *ngIf="showTitleError">
+            Title is required
+          </p>
+        </div>
+
+        <div class="field">
+          <label for="note-body" class="field-label">Body</label>
+          <textarea
+            id="note-body"
+            class="input-body"
+            placeholder="Start writing…"
+            [(ngModel)]="body"
+            (input)="onInput()"
+            rows="12"
+          ></textarea>
+        </div>
+      </div>
+
+      <div class="bottom-bar">
+        <button class="btn-cancel" (click)="onCancel()">
+          {{ isDirty ? 'Discard changes' : 'Back' }}
+        </button>
+        <button
+          class="btn-save"
+          [disabled]="!title.trim() || isSaving"
+          (click)="onSave()"
+        >
+          Save
+        </button>
+      </div>
+
+      <!-- Discard confirmation dialog -->
+      <dialog #discardDialog class="discard-dialog" aria-labelledby="discard-dialog-title" aria-modal="true" role="dialog">
+        <h2 id="discard-dialog-title">Unsaved changes</h2>
+        <p>You have unsaved changes. Discard them?</p>
+        <div class="dialog-actions">
+          <button class="btn-secondary" (click)="discardDialog.close()">Keep editing</button>
+          <button class="btn-destructive" (click)="discardAndNavigate()">Discard</button>
+        </div>
+      </dialog>
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    .editor-container {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .editor-header {
+      padding: 16px;
+    }
+    .editor-header h1 {
+      font-size: 20px;
+      margin: 0;
+    }
+
+    .form-body {
+      flex: 1;
+      padding: 0 16px;
+    }
+
+    .field { margin-bottom: 16px; }
+    .field-label {
+      display: block;
+      font-size: 13px;
+      font-weight: 600;
+      color: #374151;
+      margin-bottom: 6px;
+    }
+
+    .input-title {
+      width: 100%;
+      padding: 12px;
+      font-size: 16px;
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+      box-sizing: border-box;
+      min-height: 44px;
+    }
+    .input-title:focus { outline: 2px solid #4f46e5; outline-offset: -1px; border-color: #4f46e5; }
+    .input-title.input-error { border-color: #ef4444; }
+
+    .error-text {
+      color: #ef4444;
+      font-size: 13px;
+      margin: 4px 0 0;
+    }
+
+    .input-body {
+      width: 100%;
+      padding: 12px;
+      font-size: 16px;
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+      box-sizing: border-box;
+      resize: vertical;
+      min-height: 200px;
+      font-family: inherit;
+    }
+    .input-body:focus { outline: 2px solid #4f46e5; outline-offset: -1px; border-color: #4f46e5; }
+
+    .bottom-bar {
+      position: sticky;
+      bottom: 0;
+      background: #fff;
+      border-top: 1px solid #e5e7eb;
+      padding: 12px 16px;
+      padding-bottom: max(12px, env(safe-area-inset-bottom));
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .btn-cancel {
+      background: none;
+      border: 1px solid #d1d5db;
+      padding: 12px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+    .btn-cancel:hover { background: #f9fafb; }
+
+    .btn-save {
+      background: #4f46e5;
+      color: #fff;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+    .btn-save:hover:not(:disabled) { background: #4338ca; }
+    .btn-save:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .discard-dialog {
+      border: none;
+      border-radius: 12px;
+      padding: 24px;
+      max-width: 400px;
+      width: calc(100% - 32px);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+    .discard-dialog::backdrop { background: rgba(0,0,0,0.5); }
+    .discard-dialog h2 { margin: 0 0 8px; font-size: 18px; }
+    .discard-dialog p { margin: 0 0 24px; color: #6b7280; font-size: 14px; }
+    .dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+    }
+    .btn-secondary {
+      background: none;
+      border: 1px solid #d1d5db;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+    .btn-destructive {
+      background: #ef4444;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+  `],
+})
+export class NoteEditorComponent implements OnInit {
+  @ViewChild('discardDialog') discardDialog!: ElementRef<HTMLDialogElement>;
+
+  title = '';
+  body = '';
+  isDirty = false;
+  isSaving = false;
+  showTitleError = false;
+  isEditMode = false;
+
+  private noteId: string | null = null;
+
+  constructor(
+    private notesService: NotesService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.noteId = this.route.snapshot.paramMap.get('id');
+    if (this.noteId) {
+      this.isEditMode = true;
+      const note = this.notesService.getById(this.noteId);
+      if (!note) {
+        this.router.navigate(['/notes']);
+        return;
+      }
+      this.title = note.title;
+      this.body = note.body;
+    }
+  }
+
+  onInput(): void {
+    this.isDirty = true;
+    if (this.title.trim()) {
+      this.showTitleError = false;
+    }
+  }
+
+  onSave(): void {
+    if (!this.title.trim()) {
+      this.showTitleError = true;
+      return;
+    }
+    this.isSaving = true;
+
+    let result;
+    if (this.isEditMode && this.noteId) {
+      result = this.notesService.update(this.noteId, this.title, this.body);
+    } else {
+      result = this.notesService.create(this.title, this.body);
+    }
+
+    if (result) {
+      this.isDirty = false;
+      this.router.navigate(['/notes'], { queryParams: { saved: 'true' } });
+    } else {
+      // Save failed (quota exceeded or validation), allow retry
+      this.isSaving = false;
+    }
+  }
+
+  onCancel(): void {
+    if (this.isDirty) {
+      this.discardDialog.nativeElement.showModal();
+    } else {
+      this.router.navigate(['/notes']);
+    }
+  }
+
+  discardAndNavigate(): void {
+    this.discardDialog.nativeElement.close();
+    this.isDirty = false;
+    this.router.navigate(['/notes']);
+  }
+}

--- a/src/app/notes/note.model.ts
+++ b/src/app/notes/note.model.ts
@@ -1,0 +1,14 @@
+export interface Note {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NotesEnvelope {
+  version: 1;
+  notes: Note[];
+}
+
+export const NOTES_STORAGE_KEY = 'my-test-app-notes';

--- a/src/app/notes/notes-list.component.spec.ts
+++ b/src/app/notes/notes-list.component.spec.ts
@@ -1,0 +1,280 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotesListComponent } from './notes-list.component';
+import { NotesService } from './notes.service';
+import { Note } from './note.model';
+import { ActivatedRoute } from '@angular/router';
+import { signal, computed } from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: overrides.id ?? 'note-1',
+    title: overrides.title ?? 'Test Note',
+    body: overrides.body ?? 'Test body',
+    createdAt: overrides.createdAt ?? '2024-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2024-01-02T00:00:00.000Z',
+  };
+}
+
+function createMockService(notesList: Note[] = []) {
+  const _notes = signal<Note[]>(notesList);
+  return {
+    notes: computed(() => [..._notes()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))),
+    storageAvailable: signal(true),
+    storageFull: signal(false),
+    getStorageSizeBytes: () => 1024,
+    delete: vi.fn((id: string) => {
+      _notes.update(n => n.filter(x => x.id !== id));
+      return true;
+    }),
+    _notes,
+  };
+}
+
+describe('NotesListComponent', () => {
+  let fixture: ComponentFixture<NotesListComponent>;
+  let component: NotesListComponent;
+  let mockService: ReturnType<typeof createMockService>;
+  let mockRoute: any;
+
+  function setup(notes: Note[] = [], queryParams: Record<string, string> = {}) {
+    mockService = createMockService(notes);
+    mockRoute = {
+      snapshot: { queryParamMap: { get: (key: string) => queryParams[key] ?? null } },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [NotesListComponent],
+      providers: [
+        provideRouter([]),
+        { provide: NotesService, useValue: mockService },
+        { provide: ActivatedRoute, useValue: mockRoute },
+      ],
+    });
+
+    fixture = TestBed.createComponent(NotesListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('should create', () => {
+    setup();
+    expect(component).toBeTruthy();
+  });
+
+  describe('Empty State', () => {
+    it('should show empty state when no notes exist', () => {
+      setup([]);
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.empty-state')).toBeTruthy();
+      expect(el.textContent).toContain('No notes yet');
+      expect(el.textContent).toContain('Create your first note');
+    });
+
+    it('should not show sort label or notes grid when empty', () => {
+      setup([]);
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.sort-label')).toBeNull();
+      expect(el.querySelector('.notes-grid')).toBeNull();
+    });
+  });
+
+  describe('Notes List', () => {
+    it('should render note cards when notes exist', () => {
+      setup([makeNote(), makeNote({ id: 'note-2', title: 'Second', updatedAt: '2024-01-03T00:00:00.000Z' })]);
+      const el: HTMLElement = fixture.nativeElement;
+      const cards = el.querySelectorAll('.note-card');
+      expect(cards.length).toBe(2);
+    });
+
+    it('should show "Recently updated" label', () => {
+      setup([makeNote()]);
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.sort-label')?.textContent).toContain('Recently updated');
+    });
+
+    it('should not show empty state when notes exist', () => {
+      setup([makeNote()]);
+      expect(fixture.nativeElement.querySelector('.empty-state')).toBeNull();
+    });
+
+    it('should display note title and body', () => {
+      setup([makeNote({ title: 'My Title', body: 'My body text' })]);
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.note-title')?.textContent).toContain('My Title');
+      expect(el.querySelector('.note-body')?.textContent).toContain('My body text');
+    });
+
+    it('should show footer with note count and storage size', () => {
+      setup([makeNote()]);
+      const footer = fixture.nativeElement.querySelector('.list-footer');
+      expect(footer?.textContent).toContain('1 note');
+      expect(footer?.textContent).toContain('1KB used');
+    });
+
+    it('should pluralize note count', () => {
+      setup([makeNote(), makeNote({ id: 'note-2', updatedAt: '2024-01-03T00:00:00.000Z' })]);
+      const footer = fixture.nativeElement.querySelector('.list-footer');
+      expect(footer?.textContent).toContain('2 notes');
+    });
+
+    it('should have delete button with correct aria-label', () => {
+      setup([makeNote({ title: 'My Note' })]);
+      const btn = fixture.nativeElement.querySelector('.btn-delete');
+      expect(btn?.getAttribute('aria-label')).toBe('Delete note: My Note');
+    });
+
+    it('should link note card to edit route', () => {
+      setup([makeNote({ id: 'abc-123' })]);
+      const link = fixture.nativeElement.querySelector('.note-link');
+      expect(link?.getAttribute('href')).toBe('/notes/abc-123/edit');
+    });
+  });
+
+  describe('Delete Flow', () => {
+    it('should open dialog on delete click and set noteToDelete', () => {
+      setup([makeNote({ title: 'To Delete' })]);
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      dialog.close = vi.fn();
+
+      const deleteBtn = fixture.nativeElement.querySelector('.btn-delete');
+      deleteBtn.click();
+      fixture.detectChanges();
+
+      expect(dialog.showModal).toHaveBeenCalled();
+      expect(component.noteToDelete()?.title).toBe('To Delete');
+    });
+
+    it('should display note title in delete dialog', () => {
+      setup([makeNote({ title: 'Important Note' })]);
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      dialog.close = vi.fn();
+
+      const deleteBtn = fixture.nativeElement.querySelector('.btn-delete');
+      deleteBtn.click();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.dialog-note-title')?.textContent).toContain('Important Note');
+    });
+
+    it('should call service.delete on executeDelete', () => {
+      setup([makeNote({ id: 'del-1' })]);
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      dialog.close = vi.fn();
+
+      const deleteBtn = fixture.nativeElement.querySelector('.btn-delete');
+      deleteBtn.click();
+      fixture.detectChanges();
+
+      component.executeDelete();
+      expect(mockService.delete).toHaveBeenCalledWith('del-1');
+    });
+
+    it('should close dialog and clear noteToDelete on cancelDelete', () => {
+      setup([makeNote()]);
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      dialog.close = vi.fn();
+
+      const deleteBtn = fixture.nativeElement.querySelector('.btn-delete');
+      deleteBtn.click();
+      fixture.detectChanges();
+
+      component.cancelDelete();
+      expect(dialog.close).toHaveBeenCalled();
+      expect(component.noteToDelete()).toBeNull();
+    });
+
+    it('should show empty state after deleting last note', () => {
+      setup([makeNote({ id: 'only-one' })]);
+      const dialog = fixture.nativeElement.querySelector('dialog') as HTMLDialogElement;
+      dialog.showModal = vi.fn();
+      dialog.close = vi.fn();
+
+      const deleteBtn = fixture.nativeElement.querySelector('.btn-delete');
+      deleteBtn.click();
+      fixture.detectChanges();
+
+      component.executeDelete();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.empty-state')).toBeTruthy();
+    });
+  });
+
+  describe('Banners', () => {
+    it('should show storage unavailable banner', () => {
+      setup([]);
+      (mockService.storageAvailable as any).set(false);
+      fixture.detectChanges();
+      const banner = fixture.nativeElement.querySelector('.banner-warning');
+      expect(banner?.textContent).toContain("Your browser doesn't support local storage");
+    });
+
+    it('should show storage full banner', () => {
+      setup([makeNote()]);
+      (mockService.storageFull as any).set(true);
+      fixture.detectChanges();
+      const banner = fixture.nativeElement.querySelector('.banner-error');
+      expect(banner?.textContent).toContain('Storage is full');
+    });
+
+    it('should not show banners in normal state', () => {
+      setup([makeNote()]);
+      expect(fixture.nativeElement.querySelector('.banner-warning')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.banner-error')).toBeNull();
+    });
+  });
+
+  describe('Toast', () => {
+    it('should show toast when saved query param is true', () => {
+      vi.useFakeTimers();
+      setup([], { saved: 'true' });
+      expect(component.showToast()).toBe(true);
+      expect(fixture.nativeElement.querySelector('.toast')?.textContent).toContain('Note saved');
+      vi.advanceTimersByTime(2500);
+      expect(component.showToast()).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it('should not show toast without saved query param', () => {
+      setup([]);
+      expect(component.showToast()).toBe(false);
+      expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
+    });
+  });
+
+  describe('Dialog Accessibility', () => {
+    it('should have role="dialog" and aria-modal on delete dialog', () => {
+      setup([makeNote()]);
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog?.getAttribute('role')).toBe('dialog');
+      expect(dialog?.getAttribute('aria-modal')).toBe('true');
+      expect(dialog?.getAttribute('aria-labelledby')).toBe('delete-dialog-title');
+    });
+  });
+
+  describe('formatBytes', () => {
+    it('should format bytes under 1024 as B', () => {
+      setup([]);
+      expect(component.formatBytes(500)).toBe('500B');
+    });
+
+    it('should format bytes over 1024 as KB', () => {
+      setup([]);
+      expect(component.formatBytes(2048)).toBe('2KB');
+    });
+  });
+
+  describe('Tracking', () => {
+    it('should log notes_list_viewed on init', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      setup([makeNote()]);
+      expect(spy).toHaveBeenCalledWith('[track] notes_list_viewed', { noteCount: 1 });
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/app/notes/notes-list.component.ts
+++ b/src/app/notes/notes-list.component.ts
@@ -1,0 +1,386 @@
+import { Component, OnInit, ElementRef, ViewChild, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, ActivatedRoute, Router } from '@angular/router';
+import { NotesService } from './notes.service';
+import { Note } from './note.model';
+import { RelativeTimePipe } from './relative-time.pipe';
+
+@Component({
+  selector: 'app-notes-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, RelativeTimePipe],
+  template: `
+    <!-- Storage unavailable banner -->
+    <div class="banner banner-warning" *ngIf="!notesService.storageAvailable()">
+      Your browser doesn't support local storage. Notes will not be saved between sessions.
+    </div>
+
+    <!-- Storage full banner -->
+    <div class="banner banner-error" *ngIf="notesService.storageFull()">
+      Storage is full. Please delete some notes to save new ones.
+    </div>
+
+    <!-- Toast -->
+    <div class="toast" *ngIf="showToast()" role="status" aria-live="polite">
+      Note saved
+    </div>
+
+    <header class="toolbar">
+      <h1 #pageHeading tabindex="-1">Notes</h1>
+      <button class="btn-primary new-note-desktop" routerLink="/notes/new">+ New Note</button>
+    </header>
+
+    <!-- Empty state -->
+    <div class="empty-state" *ngIf="notesService.notes().length === 0">
+      <svg class="empty-icon" viewBox="0 0 64 64" width="64" height="64" aria-hidden="true">
+        <rect x="12" y="8" width="40" height="48" rx="4" fill="none" stroke="currentColor" stroke-width="2"/>
+        <line x1="20" y1="20" x2="44" y2="20" stroke="currentColor" stroke-width="2"/>
+        <line x1="20" y1="28" x2="44" y2="28" stroke="currentColor" stroke-width="2"/>
+        <line x1="20" y1="36" x2="36" y2="36" stroke="currentColor" stroke-width="2"/>
+        <circle cx="48" cy="48" r="12" fill="currentColor" opacity="0.1"/>
+        <line x1="44" y1="48" x2="52" y2="48" stroke="currentColor" stroke-width="2"/>
+        <line x1="48" y1="44" x2="48" y2="52" stroke="currentColor" stroke-width="2"/>
+      </svg>
+      <p class="empty-message">No notes yet</p>
+      <button class="btn-primary" routerLink="/notes/new">Create your first note</button>
+    </div>
+
+    <!-- Notes list -->
+    <ng-container *ngIf="notesService.notes().length > 0">
+      <p class="sort-label">Recently updated</p>
+      <div class="notes-grid">
+        <article class="note-card" *ngFor="let note of notesService.notes()">
+          <a class="note-link" [routerLink]="['/notes', note.id, 'edit']">
+            <h2 class="note-title">{{ note.title }}</h2>
+            <p class="note-body">{{ note.body }}</p>
+            <time class="note-time" [attr.title]="note.updatedAt">
+              {{ note.updatedAt | relativeTime }}
+            </time>
+          </a>
+          <button
+            class="btn-delete"
+            [attr.aria-label]="'Delete note: ' + note.title"
+            (click)="confirmDelete(note, $event)"
+            #deleteBtn
+          >
+            <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+              <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14M10 11v6M14 11v6"
+                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+        </article>
+      </div>
+
+      <footer class="list-footer">
+        {{ notesService.notes().length }} note{{ notesService.notes().length === 1 ? '' : 's' }}
+        &middot; {{ formatBytes(notesService.getStorageSizeBytes()) }} used
+      </footer>
+    </ng-container>
+
+    <!-- FAB for mobile -->
+    <button class="fab" routerLink="/notes/new" aria-label="New Note">+</button>
+
+    <!-- Delete confirmation dialog -->
+    <dialog #deleteDialog class="delete-dialog" aria-labelledby="delete-dialog-title" aria-modal="true" role="dialog">
+      <h2 id="delete-dialog-title">Delete this note?</h2>
+      <p class="dialog-note-title" *ngIf="noteToDelete()">{{ noteToDelete()!.title }}</p>
+      <div class="dialog-actions">
+        <button class="btn-secondary" (click)="cancelDelete()">Cancel</button>
+        <button class="btn-destructive" (click)="executeDelete()">Delete</button>
+      </div>
+    </dialog>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 16px;
+      padding-bottom: 80px;
+    }
+
+    .banner {
+      padding: 12px 16px;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      font-size: 14px;
+    }
+    .banner-warning {
+      background: #fff3cd;
+      color: #856404;
+      border: 1px solid #ffc107;
+    }
+    .banner-error {
+      background: #f8d7da;
+      color: #721c24;
+      border: 1px solid #f5c6cb;
+    }
+
+    .toast {
+      position: fixed;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #323232;
+      color: #fff;
+      padding: 12px 24px;
+      border-radius: 8px;
+      z-index: 1000;
+      font-size: 14px;
+      animation: fadeIn 0.2s ease;
+    }
+    @keyframes fadeIn { from { opacity: 0; transform: translateX(-50%) translateY(-8px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
+
+    .toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+    .toolbar h1 {
+      font-size: 24px;
+      margin: 0;
+    }
+
+    .btn-primary {
+      background: #4f46e5;
+      color: #fff;
+      border: none;
+      padding: 12px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+    }
+    .btn-primary:hover { background: #4338ca; }
+
+    .new-note-desktop { display: none; }
+    @media (min-width: 600px) {
+      .new-note-desktop { display: inline-flex; }
+      .fab { display: none !important; }
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 64px 16px;
+      color: #6b7280;
+    }
+    .empty-icon { color: #9ca3af; margin-bottom: 16px; }
+    .empty-message { font-size: 18px; margin: 0 0 24px; }
+
+    .sort-label {
+      font-size: 13px;
+      color: #6b7280;
+      margin: 0 0 8px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .notes-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .note-card {
+      position: relative;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      overflow: hidden;
+      transition: box-shadow 0.15s;
+    }
+    .note-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+
+    .note-link {
+      display: block;
+      padding: 16px;
+      padding-right: 56px;
+      text-decoration: none;
+      color: inherit;
+      min-height: 44px;
+    }
+
+    .note-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0 0 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .note-body {
+      font-size: 14px;
+      color: #6b7280;
+      margin: 0 0 8px;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .note-time {
+      font-size: 12px;
+      color: #9ca3af;
+    }
+
+    .btn-delete {
+      position: absolute;
+      top: 12px;
+      right: 8px;
+      background: none;
+      border: none;
+      padding: 12px;
+      cursor: pointer;
+      color: #9ca3af;
+      border-radius: 8px;
+      min-width: 44px;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn-delete:hover { color: #ef4444; background: #fef2f2; }
+
+    .list-footer {
+      text-align: center;
+      padding: 16px;
+      font-size: 13px;
+      color: #9ca3af;
+    }
+
+    .fab {
+      position: fixed;
+      bottom: 16px;
+      right: 16px;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: #4f46e5;
+      color: #fff;
+      border: none;
+      font-size: 28px;
+      cursor: pointer;
+      box-shadow: 0 4px 12px rgba(79,70,229,0.4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+      min-width: 44px;
+      min-height: 44px;
+    }
+    .fab:hover { background: #4338ca; }
+
+    .delete-dialog {
+      border: none;
+      border-radius: 12px;
+      padding: 24px;
+      max-width: 400px;
+      width: calc(100% - 32px);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+    .delete-dialog::backdrop {
+      background: rgba(0,0,0,0.5);
+    }
+    .delete-dialog h2 {
+      margin: 0 0 8px;
+      font-size: 18px;
+    }
+    .dialog-note-title {
+      font-size: 14px;
+      color: #6b7280;
+      margin: 0 0 24px;
+      font-style: italic;
+    }
+    .dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+    }
+    .btn-secondary {
+      background: none;
+      border: 1px solid #d1d5db;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+    .btn-secondary:hover { background: #f9fafb; }
+    .btn-destructive {
+      background: #ef4444;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+    .btn-destructive:hover { background: #dc2626; }
+  `],
+})
+export class NotesListComponent implements OnInit {
+  @ViewChild('deleteDialog') deleteDialog!: ElementRef<HTMLDialogElement>;
+  @ViewChild('pageHeading') pageHeading!: ElementRef<HTMLHeadingElement>;
+
+  noteToDelete = signal<Note | null>(null);
+  showToast = signal(false);
+
+  private deleteTriggeredBy: HTMLElement | null = null;
+
+  constructor(
+    public notesService: NotesService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    console.log('[track] notes_list_viewed', { noteCount: this.notesService.notes().length });
+
+    // Check for toast query param
+    if (this.route.snapshot.queryParamMap.get('saved') === 'true') {
+      this.showToast.set(true);
+      this.router.navigate([], { queryParams: {}, replaceUrl: true });
+      setTimeout(() => this.showToast.set(false), 2500);
+    }
+  }
+
+  confirmDelete(note: Note, event: Event): void {
+    this.noteToDelete.set(note);
+    this.deleteTriggeredBy = event.currentTarget as HTMLElement;
+    this.deleteDialog.nativeElement.showModal();
+  }
+
+  cancelDelete(): void {
+    this.deleteDialog.nativeElement.close();
+    this.noteToDelete.set(null);
+    this.deleteTriggeredBy?.focus();
+    this.deleteTriggeredBy = null;
+  }
+
+  executeDelete(): void {
+    const note = this.noteToDelete();
+    if (note) {
+      this.notesService.delete(note.id);
+    }
+    this.deleteDialog.nativeElement.close();
+    this.noteToDelete.set(null);
+    this.deleteTriggeredBy = null;
+    this.pageHeading?.nativeElement?.focus();
+  }
+
+  formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`;
+    return `${Math.round(bytes / 1024)}KB`;
+  }
+}

--- a/src/app/notes/notes.service.spec.ts
+++ b/src/app/notes/notes.service.spec.ts
@@ -1,0 +1,173 @@
+import { TestBed } from '@angular/core/testing';
+import { NotesService } from './notes.service';
+import { NOTES_STORAGE_KEY, NotesEnvelope } from './note.model';
+
+function createMockStorage() {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    _store: store,
+  };
+}
+
+describe('NotesService', () => {
+  let service: NotesService;
+  let mockStorage: ReturnType<typeof createMockStorage>;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    vi.stubGlobal('localStorage', mockStorage);
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotesService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should detect storage availability', () => {
+    expect(service.storageAvailable()).toBe(true);
+  });
+
+  it('should create a note', () => {
+    const note = service.create('Test Title', 'Test Body');
+    expect(note).toBeTruthy();
+    expect(note!.title).toBe('Test Title');
+    expect(note!.body).toBe('Test Body');
+    expect(note!.id).toBeTruthy();
+    expect(note!.createdAt).toBeTruthy();
+    expect(service.getAll().length).toBe(1);
+  });
+
+  it('should reject empty title', () => {
+    const note = service.create('   ', 'body');
+    expect(note).toBeNull();
+    expect(service.getAll().length).toBe(0);
+  });
+
+  it('should trim title on create', () => {
+    const note = service.create('  Trimmed  ', 'body');
+    expect(note!.title).toBe('Trimmed');
+  });
+
+  it('should persist to localStorage', () => {
+    service.create('Persisted', 'body');
+    const raw = mockStorage.getItem(NOTES_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const envelope: NotesEnvelope = JSON.parse(raw!);
+    expect(envelope.version).toBe(1);
+    expect(envelope.notes.length).toBe(1);
+    expect(envelope.notes[0].title).toBe('Persisted');
+  });
+
+  it('should get note by id', () => {
+    const created = service.create('Find Me', 'body')!;
+    const found = service.getById(created.id);
+    expect(found).toBeTruthy();
+    expect(found!.title).toBe('Find Me');
+  });
+
+  it('should return null for unknown id', () => {
+    expect(service.getById('nonexistent')).toBeNull();
+  });
+
+  it('should update a note', async () => {
+    const created = service.create('Original', 'body')!;
+    // Ensure timestamp differs
+    await new Promise((r) => setTimeout(r, 10));
+    const updated = service.update(created.id, 'Updated', 'new body');
+    expect(updated).toBeTruthy();
+    expect(updated!.title).toBe('Updated');
+    expect(updated!.body).toBe('new body');
+    expect(updated!.updatedAt >= created.updatedAt).toBe(true);
+  });
+
+  it('should return null when updating nonexistent note', () => {
+    expect(service.update('bad-id', 'Title', 'body')).toBeNull();
+  });
+
+  it('should delete a note', () => {
+    const created = service.create('Delete Me', 'body')!;
+    expect(service.delete(created.id)).toBe(true);
+    expect(service.getAll().length).toBe(0);
+  });
+
+  it('should return false when deleting nonexistent note', () => {
+    expect(service.delete('bad-id')).toBe(false);
+  });
+
+  it('should sort notes by updatedAt descending', async () => {
+    service.create('First', 'body');
+    await new Promise((r) => setTimeout(r, 10));
+    service.create('Second', 'body');
+    const notes = service.getAll();
+    expect(notes[0].title).toBe('Second');
+    expect(notes[1].title).toBe('First');
+  });
+
+  it('should handle corrupted localStorage gracefully', () => {
+    mockStorage.setItem(NOTES_STORAGE_KEY, 'not valid json!!!');
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Re-create service to trigger load
+    const newService = new NotesService();
+    expect(newService.getAll().length).toBe(0);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('should handle QuotaExceededError', () => {
+    const originalSetItem = mockStorage.setItem;
+    let callCount = 0;
+    mockStorage.setItem = (key: string, value: string) => {
+      callCount++;
+      // Allow the probe write but fail on actual storage
+      if (key === NOTES_STORAGE_KEY) {
+        const err = new DOMException('Quota exceeded', 'QuotaExceededError');
+        throw err;
+      }
+      originalSetItem.call(mockStorage, key, value);
+    };
+    const result = service.create('Overflow', 'big body');
+    expect(result).toBeNull();
+    expect(service.storageFull()).toBe(true);
+  });
+
+  it('should return storage size in bytes', () => {
+    service.create('Size test', 'body');
+    const size = service.getStorageSizeBytes();
+    expect(size).toBeGreaterThan(0);
+  });
+
+  it('should increment notesCreatedThisSession', () => {
+    expect(service.notesCreatedThisSession).toBe(0);
+    service.create('One', 'body');
+    expect(service.notesCreatedThisSession).toBe(1);
+    service.create('Two', 'body');
+    expect(service.notesCreatedThisSession).toBe(2);
+  });
+
+  it('should load existing notes from localStorage on init', () => {
+    const envelope: NotesEnvelope = {
+      version: 1,
+      notes: [{
+        id: 'existing-id',
+        title: 'Pre-existing',
+        body: 'body',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      }],
+    };
+    mockStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(envelope));
+    const newService = new NotesService();
+    expect(newService.getAll().length).toBe(1);
+    expect(newService.getAll()[0].title).toBe('Pre-existing');
+  });
+});

--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, signal, computed, inject, DestroyRef } from '@angular/core';
+import { Note, NotesEnvelope, NOTES_STORAGE_KEY } from './note.model';
+
+@Injectable({ providedIn: 'root' })
+export class NotesService {
+  private readonly _notes = signal<Note[]>([]);
+  private readonly _storageAvailable = signal(false);
+  private readonly _storageFull = signal(false);
+
+  readonly notes = computed(() =>
+    [...this._notes()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  );
+  readonly storageAvailable = this._storageAvailable.asReadonly();
+  readonly storageFull = this._storageFull.asReadonly();
+
+  notesCreatedThisSession = 0;
+
+  constructor() {
+    this._storageAvailable.set(this.probeStorage());
+    this.loadFromStorage();
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', (event) => {
+        if (event.key === NOTES_STORAGE_KEY) {
+          this.loadFromStorage();
+        }
+      });
+    }
+  }
+
+  private probeStorage(): boolean {
+    try {
+      const testKey = '__storage_test__';
+      localStorage.setItem(testKey, 'test');
+      const val = localStorage.getItem(testKey);
+      localStorage.removeItem(testKey);
+      return val === 'test';
+    } catch {
+      return false;
+    }
+  }
+
+  private loadFromStorage(): void {
+    if (!this._storageAvailable()) return;
+    try {
+      const raw = localStorage.getItem(NOTES_STORAGE_KEY);
+      if (!raw) {
+        this._notes.set([]);
+        return;
+      }
+      const envelope: NotesEnvelope = JSON.parse(raw);
+      if (envelope && envelope.version === 1 && Array.isArray(envelope.notes)) {
+        this._notes.set(envelope.notes);
+      } else {
+        console.warn('Invalid notes envelope structure, resetting to empty');
+        this._notes.set([]);
+      }
+    } catch (e) {
+      console.warn('Failed to parse notes from localStorage', e);
+      this._notes.set([]);
+    }
+  }
+
+  private persist(): boolean {
+    if (!this._storageAvailable()) return true;
+    try {
+      const envelope: NotesEnvelope = { version: 1, notes: this._notes() };
+      localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(envelope));
+      this._storageFull.set(false);
+      return true;
+    } catch (e: unknown) {
+      if (e instanceof DOMException && (e.name === 'QuotaExceededError' || e.code === 22)) {
+        this._storageFull.set(true);
+      }
+      return false;
+    }
+  }
+
+  getAll(): Note[] {
+    return this.notes();
+  }
+
+  getById(id: string): Note | null {
+    return this._notes().find((n) => n.id === id) ?? null;
+  }
+
+  create(title: string, body: string): Note | null {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return null;
+
+    const now = new Date().toISOString();
+    const note: Note = {
+      id: crypto.randomUUID(),
+      title: trimmedTitle,
+      body: body,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this._notes.update((notes) => [...notes, note]);
+    if (!this.persist()) {
+      // Rollback
+      this._notes.update((notes) => notes.filter((n) => n.id !== note.id));
+      return null;
+    }
+    this.notesCreatedThisSession++;
+    console.log('[track] note_created', {
+      noteId: note.id,
+      titleLength: note.title.length,
+      bodyLength: note.body.length,
+    });
+    return note;
+  }
+
+  update(id: string, title: string, body: string): Note | null {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return null;
+
+    const existing = this.getById(id);
+    if (!existing) return null;
+
+    const updated: Note = {
+      ...existing,
+      title: trimmedTitle,
+      body: body,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const oldNotes = this._notes();
+    this._notes.update((notes) => notes.map((n) => (n.id === id ? updated : n)));
+    if (!this.persist()) {
+      this._notes.set(oldNotes);
+      return null;
+    }
+    console.log('[track] note_updated', { noteId: id });
+    return updated;
+  }
+
+  delete(id: string): boolean {
+    const existing = this.getById(id);
+    if (!existing) return false;
+
+    const oldNotes = this._notes();
+    this._notes.update((notes) => notes.filter((n) => n.id !== id));
+    if (!this.persist()) {
+      this._notes.set(oldNotes);
+      return false;
+    }
+    console.log('[track] note_deleted', { noteId: id });
+    return true;
+  }
+
+  getStorageSizeBytes(): number {
+    if (!this._storageAvailable()) return 0;
+    return new Blob([localStorage.getItem(NOTES_STORAGE_KEY) ?? '']).size;
+  }
+}

--- a/src/app/notes/relative-time.pipe.spec.ts
+++ b/src/app/notes/relative-time.pipe.spec.ts
@@ -1,0 +1,33 @@
+import { RelativeTimePipe } from './relative-time.pipe';
+
+describe('RelativeTimePipe', () => {
+  const pipe = new RelativeTimePipe();
+
+  it('should return "just now" for recent timestamps', () => {
+    expect(pipe.transform(new Date().toISOString())).toBe('just now');
+  });
+
+  it('should return minutes ago', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(pipe.transform(fiveMinAgo)).toBe('5 min ago');
+  });
+
+  it('should return hours ago', () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(pipe.transform(threeHoursAgo)).toBe('3h ago');
+  });
+
+  it('should return Yesterday', () => {
+    const yesterday = new Date(Date.now() - 26 * 60 * 60 * 1000).toISOString();
+    expect(pipe.transform(yesterday)).toBe('Yesterday');
+  });
+
+  it('should return days ago', () => {
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    expect(pipe.transform(fiveDaysAgo)).toBe('5d ago');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+});

--- a/src/app/notes/relative-time.pipe.ts
+++ b/src/app/notes/relative-time.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'relativeTime',
+  standalone: true,
+  pure: true,
+})
+export class RelativeTimePipe implements PipeTransform {
+  transform(isoString: string): string {
+    if (!isoString) return '';
+
+    const now = Date.now();
+    const then = new Date(isoString).getTime();
+    const diffSeconds = Math.floor((now - then) / 1000);
+
+    if (diffSeconds < 60) return 'just now';
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    if (diffMinutes < 60) return `${diffMinutes} min ago`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 30) return `${diffDays}d ago`;
+    const diffMonths = Math.floor(diffDays / 30);
+    if (diffMonths < 12) return `${diffMonths}mo ago`;
+    const diffYears = Math.floor(diffDays / 365);
+    return `${diffYears}y ago`;
+  }
+}


### PR DESCRIPTION
## ⚠️ Pipeline Failed

**Reason:** Pipeline failed after 2 loop(s). Tests are FAILING.

### Test Failures
```
Test failed (`npm run test`):

> my-test-app@0.0.0 test
> ng test

[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                    [2m | [22m[1mNames[22m                               [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                        [2m | [22m[2mspec-app-app[22m                        [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mchunk-ZMMAKB6I.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m [36m26.91 kB[39m[2m | [22m
[32mchunk-ODZ23PHH.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m [36m17.68 kB[39m[2m | [22m
[32mspec-app-notes-notes-list.component.js[39m [2m | [22m[2mspec-app-notes-notes-list.component[22m [2m | [22m  [36m9.98 kB[39m[2m | [22m
[32mspec-app-notes-note-editor.component.js[39m[2m | [22m[2mspec-app-notes-note-editor.component[22m[2m | [22m  [36m8.32 kB[39m[2m | [22m
[32mspec-app-notes-notes.service.js[39m        [2m | [22m[2mspec-app-notes-notes.service[22m        [2m | [22m  [36m5.58 kB[39m[2m | [22m
[32mchunk-2ZVBY5XJ.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m  [36m5.06 kB[39m[2m | [22m
[32mchunk-RSTWSNOR.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m  [36m4.75 kB[39m[2m | [22m
[32mspec-app-app.routes.js[39m                 
… (truncated)
```

### Diagnostic
Pipeline exhausted after 2 review loop(s).

### Test Failures
```
Test failed (`npm run test`):

> my-test-app@0.0.0 test
> ng test

[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                    [2m | [22m[1mNames[22m                               [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                        [2m | [22m[2mspec-app-app[22m                        [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mchunk-ZMMAKB6I.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m [36m26.91 kB[39m[2m | [22m
[32mchunk-ODZ23PHH.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m [36m17.68 kB[39m[2m | [22m
[32mspec-app-notes-notes-list.component.js[39m [2m | [22m[2mspec-app-notes-notes-list.component[22m [2m | [22m  [36m9.98 kB[39m[2m | [22m
[32mspec-app-notes-note-editor.component.js[39m[2m | [22m[2mspec-app-notes-note-editor.component[22m[2m | [22m  [36m8.32 kB[39m[2m | [22m
[32mspec-app-notes-notes.service.js[39m        [2m | [22m[2mspec-app-notes-notes.service[22m        [2m | [22m  [36m5.58 kB[39m[2m | [22m
[32mchunk-2ZVBY5XJ.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m  [36m5.06 kB[39m[2m | [22m
[32mchunk-RSTWSNOR.js[39m                      [2m | [22m[2m-[22m                                   [2m | [22m  [36m4.75 kB[39m[2m | [22m
[32mspec-app-app.routes.js[39m                 
… (truncated)
```

### Recommended Next Steps
- Review the issues above and provide `--guidance` on the next run
- Re-run with the same `branch` input to continue from this code state

### How to Continue

**Option 1:** Comment on this PR:
`/bmad retry Your guidance here`

**Option 2:** Manual dispatch:
```
gh workflow run bmad-start-run.yml \
  -f target_repo="diegosramirez/my-test-app" \
  -f branch="bmad/sam1/SAM1-188-create-a-notes-taking-feature-for-the-ap" \
  -f prompt="Create a notes taking feature for the app (no backend)" \
  -f team_id="SAM1" \
  -f skip_check_epic_state=true \
  -f skip_create_or_correct_epic=true \
  -f skip_create_story_tasks=true \
  -f skip_party_mode_refinement=true \
  -f extra_flags="--story-key SAM1-188 --retry"
```

---
## Story
**SAM1-188**: **Hypothesis**

## Acceptance Criteria
- Given I am on `/notes`, when I click 'New Note', fill in a non-empty title and body, and click Save, then the note appears at the top of the notes list, is persisted in localStorage within the versioned envelope `{ version: 1, notes: Note[] }`, and a brief 'Note saved' toast is displayed.
- Given I have saved notes, when I navigate to `/notes`, then I see all notes with CSS-truncated title (1 line), body preview (2 lines via `-webkit-line-clamp`), and relative timestamp, sorted by `updatedAt` descending, with a 'Recently updated' label above the list.
- Given a note exists, when I navigate to `/notes/:id/edit`, modify the title or body, and click Save, then the changes are persisted, `updatedAt` is refreshed, and I am redirected to `/notes` with a 'Note saved' toast.
- Given a note exists, when I click the Delete icon and confirm in the native `<dialog>` confirmation (which displays the note title), then the note is removed from the list and localStorage; if no notes remain, the empty state with icon and 'Create your first note' CTA is displayed.
- Given no notes exist, when I navigate to `/notes`, then I see a friendly empty-state with icon/illustration, message, and a 'Create your first note' CTA button matching the primary 'New Note' visual treatment.
- Given I have created notes and refresh the browser, then all notes are still present and correctly rendered from the versioned localStorage envelope. Given `/notes` is open in two tabs and a note is deleted in one, the other tab updates via the `window 'storage'` event.
- Given localStorage is full, when I attempt to save, then an inline banner states 'Storage is full. Please delete some notes to save new ones' and the save does not silently fail. Given localStorage is unavailable, a persistent banner warns notes will not persist and the feature operates in memory-only mode.
- Given the codebase, when inspected, then no NgModule or `app.module.ts` exists; all components use `standalone: true`; all interactive elements have minimum 44x44px touch targets; the delete dialog uses native `<dialog>` with `showModal()`, traps focus, is Escape-dismissible, and uses `role='dialog'` and `aria-modal='true'`.

## Implementation Details
### Architecture


# Technical Architecture Review: Notes Feature

## Data Model

The note entity is straightforward. Define a TypeScript interface in a dedicated file at `src/app/notes/note.model.ts`:

```typescript
export interface Note {
  id: string;
  title: string;
  body: string;
  createdAt: string; // ISO 8601
  updatedAt: string; // ISO 8601
}
```

- The `id` field should be generated via `crypto.randomUUID()`, which is available in all modern browsers and avoids pulling in a UUID library. Provide a fallback only if you must support very old WebView targets.
- The localStorage key `my-test-app-notes`

### Developer Notes
**Data Model and Storage**
- Define `Note` interface and `NotesEnvelope` type (`{ version: 1, notes: Note[] }`) in `src/app/notes/note.model.ts`. Export `NOTES_STORAGE_KEY = 'my-test-app-notes'` constant.
- Generate IDs via `crypto.randomUUID()`. Generate timestamps via `new Date().toISOString()` — never from user input.
- Wrap `JSON.parse` in try/catch; on failure, log `console.warn` and return empty array. Wrap `localStorage.setItem` in try/catch for `QuotaExceededError`.

**NotesService (`src/app/notes/notes.service.ts`)**
- Singleton via `providedIn: 'root'`. Use Angular signals (`signal<N

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/note-editor.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/note-editor.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/note.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/notes-list.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/notes-list.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/notes.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/notes.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/relative-time.pipe.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notes/relative-time.pipe.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
Pipeline failed with 0 unresolved issue(s) after 2 review loop(s).

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Create a notes taking feature for the app (no backend) -->
<!-- bmad:team_id=SAM1 -->