### PR TITLE
feat(SAM1): Add a searchable command palette (Cmd+K / Ctrl+K) that lets  [SAM1-202]

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
-
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { routes } from './app.routes';
+import { provideDefaultCommands } from './command-palette/commands.initializer';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideAnimationsAsync(),
+    provideDefaultCommands(),
   ]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -339,4 +339,13 @@
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 
 
+<nav class="top-nav">
+  <button class="palette-trigger" (click)="openPalette()">
+    Search or jump to&hellip;
+    <kbd class="palette-trigger-shortcut">{{ isMac ? '⌘K' : 'Ctrl+K' }}</kbd>
+  </button>
+</nav>
+
 <router-outlet />
+
+<app-command-palette />

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+  { path: 'dashboard', loadComponent: () => import('./pages/dashboard/dashboard.component').then(m => m.DashboardComponent) },
+  { path: 'profile', loadComponent: () => import('./pages/profile/profile.component').then(m => m.ProfileComponent) },
+  { path: 'settings', loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent) },
+  { path: 'help', loadComponent: () => import('./pages/help/help.component').then(m => m.HelpComponent) },
+];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,12 +1,23 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { CommandPaletteComponent } from './command-palette/command-palette.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, CommandPaletteComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
 export class App {
   protected readonly title = signal('my-test-app');
+  @ViewChild(CommandPaletteComponent) commandPalette!: CommandPaletteComponent;
+
+  get isMac(): boolean {
+    // TODO: SSR guard
+    return typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  }
+
+  openPalette(): void {
+    this.commandPalette.open('ui');
+  }
 }

--- a/src/app/command-palette/command-palette.component.spec.ts
+++ b/src/app/command-palette/command-palette.component.spec.ts
@@ -1,0 +1,407 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { CommandPaletteComponent } from './command-palette.component';
+import { CommandRegistryService } from './command-registry.service';
+import { AnalyticsService } from '../shared/analytics.service';
+import { RecentCommandsService } from './recent-commands.service';
+import { Command } from './command.model';
+
+describe('CommandPaletteComponent', () => {
+  let fixture: ComponentFixture<CommandPaletteComponent>;
+  let component: CommandPaletteComponent;
+  let registry: CommandRegistryService;
+  let analytics: AnalyticsService;
+  let analyticsSpy: ReturnType<typeof vi.spyOn>;
+
+  const makeCommand = (id: string, label: string, keywords: string[] = [], category: 'navigation' | 'action' = 'navigation'): Command => ({
+    id,
+    label,
+    category,
+    keywords,
+    execute: vi.fn(),
+  });
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+      imports: [CommandPaletteComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    registry = TestBed.inject(CommandRegistryService);
+    analytics = TestBed.inject(AnalyticsService);
+    analyticsSpy = vi.spyOn(analytics, 'track');
+
+    fixture = TestBed.createComponent(CommandPaletteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function openPalette(method: 'keyboard' | 'ui' = 'keyboard') {
+    component.open(method);
+    // Double detectChanges to satisfy Angular dev-mode ExpressionChanged check
+    // after imperatively toggling isOpen from false to true
+    fixture.detectChanges();
+    vi.advanceTimersByTime(1); // flush setTimeout for focus
+    fixture.detectChanges();
+  }
+
+  function getElement(selector: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(selector);
+  }
+
+  function simulateInput(value: string) {
+    const input = getElement('.palette-input') as HTMLInputElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
+
+  // --- Palette Opens ---
+
+  it('should not render palette initially', () => {
+    expect(getElement('[role="dialog"]')).toBeNull();
+  });
+
+  it('should open via open() method and fire analytics', () => {
+    openPalette('ui');
+    expect(getElement('[role="dialog"]')).toBeTruthy();
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_opened', { trigger_method: 'ui' });
+  });
+
+  it('should open via keyboard shortcut (Ctrl+K)', () => {
+    const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true });
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+    document.dispatchEvent(event);
+    fixture.detectChanges();
+    expect(component.isOpen).toBe(true);
+    expect(preventSpy).toHaveBeenCalled();
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_opened', { trigger_method: 'keyboard' });
+  });
+
+  it('should open via Meta+K (macOS)', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }));
+    fixture.detectChanges();
+    expect(component.isOpen).toBe(true);
+  });
+
+  it('should not open when already closing (rapid toggle guard)', () => {
+    openPalette();
+    component.isClosing = true;
+    component.open('ui');
+    // Should still be in closing state, not reopened
+    expect(component.isClosing).toBe(true);
+  });
+
+  // --- Idempotent Cmd+K when open ---
+
+  it('should clear query and refocus when Cmd+K pressed while open', () => {
+    registry.register(makeCommand('a', 'Test'));
+    openPalette();
+    simulateInput('hello');
+    vi.advanceTimersByTime(100);
+    expect(component.query).toBe('hello');
+
+    // Press Ctrl+K again
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+    fixture.detectChanges();
+    vi.advanceTimersByTime(1);
+    expect(component.query).toBe('');
+    expect(component.isOpen).toBe(true);
+  });
+
+  // --- Fuzzy Search ---
+
+  it('should filter commands via fuzzy search after debounce', () => {
+    registry.register(makeCommand('nav:dashboard', 'Go to Dashboard', ['home']));
+    registry.register(makeCommand('nav:profile', 'Go to Profile', ['account']));
+    openPalette();
+
+    simulateInput('Dashboard');
+    vi.advanceTimersByTime(100);
+    fixture.detectChanges();
+
+    expect(component.displayedItems.length).toBe(1);
+    expect(component.displayedItems[0].id).toBe('nav:dashboard');
+  });
+
+  it('should show no results message when search has no matches', () => {
+    registry.register(makeCommand('a', 'Test'));
+    openPalette();
+
+    simulateInput('xyznonexistent');
+    vi.advanceTimersByTime(100);
+    fixture.detectChanges();
+
+    expect(component.displayedItems.length).toBe(0);
+    const empty = getElement('.palette-empty');
+    expect(empty?.textContent).toContain('No results for');
+    expect(empty?.textContent).toContain('xyznonexistent');
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_no_results', { query_text: 'xyznonexistent' });
+  });
+
+  it('should show "No commands available" when registry is empty and no query', () => {
+    openPalette();
+    expect(getElement('.palette-empty')?.textContent).toContain('No commands available');
+  });
+
+  it('should restore recent items when query cleared', () => {
+    registry.register(makeCommand('a', 'Alpha'));
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('a');
+    openPalette();
+    expect(component.displayedItems.length).toBe(1);
+
+    simulateInput('something');
+    vi.advanceTimersByTime(100);
+    fixture.detectChanges();
+
+    simulateInput('');
+    fixture.detectChanges();
+    expect(component.displayedItems.length).toBe(1);
+    expect(component.displayedItems[0].id).toBe('a');
+  });
+
+  // --- Keyboard Navigation ---
+
+  it('should move selection with arrow keys and wrap', () => {
+    registry.register(makeCommand('a', 'Alpha'));
+    registry.register(makeCommand('b', 'Beta'));
+    registry.register(makeCommand('c', 'Gamma'));
+    // Push all to recents so they show
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('c');
+    recentService.pushRecent('b');
+    recentService.pushRecent('a');
+    openPalette();
+
+    expect(component.selectedIndex).toBe(0);
+
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    expect(component.selectedIndex).toBe(1);
+
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    expect(component.selectedIndex).toBe(2);
+
+    // Wrap to beginning
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    expect(component.selectedIndex).toBe(0);
+
+    // Wrap to end (ArrowUp from 0)
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    expect(component.selectedIndex).toBe(2);
+  });
+
+  it('should update selection on mouse enter', () => {
+    component.onMouseEnter(3);
+    expect(component.selectedIndex).toBe(3);
+  });
+
+  // --- Command Execution ---
+
+  it('should execute command on Enter and fire analytics with duration_ms', () => {
+    const cmd = makeCommand('a', 'Alpha');
+    registry.register(cmd);
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('a');
+    openPalette();
+
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    expect(cmd.execute).toHaveBeenCalled();
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_executed', expect.objectContaining({
+      command_id: 'a',
+      command_category: 'navigation',
+      duration_ms: expect.any(Number),
+    }));
+  });
+
+  it('should add executed command to recent items', () => {
+    const cmd = makeCommand('a', 'Alpha');
+    registry.register(cmd);
+    const recentService = TestBed.inject(RecentCommandsService);
+    const pushSpy = vi.spyOn(recentService, 'pushRecent');
+    openPalette();
+    component.displayedItems = [cmd];
+    component.selectedIndex = 0;
+
+    component.executeCommand(cmd);
+    expect(pushSpy).toHaveBeenCalledWith('a');
+  });
+
+  it('should handle command execution failure gracefully', () => {
+    const cmd: Command = {
+      id: 'fail',
+      label: 'Fail',
+      category: 'action',
+      keywords: [],
+      execute: () => { throw new Error('boom'); },
+    };
+    registry.register(cmd);
+    openPalette();
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    component.executeCommand(cmd);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(component.isClosing).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  // --- Dismissal ---
+
+  it('should dismiss on Escape and fire analytics', () => {
+    openPalette();
+    component.query = 'test';
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(component.isClosing).toBe(true);
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_dismissed', {
+      had_query: true,
+      dismiss_method: 'escape',
+    });
+  });
+
+  it('should dismiss on click outside and fire analytics', () => {
+    openPalette();
+    component.dismissViaClickOutside();
+    expect(component.isClosing).toBe(true);
+    expect(analyticsSpy).toHaveBeenCalledWith('command_palette_dismissed', {
+      had_query: false,
+      dismiss_method: 'click_outside',
+    });
+  });
+
+  it('should complete close on animation end', () => {
+    openPalette();
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(component.isOpen).toBe(true); // still open during animation
+    component.onAnimationEnd();
+    expect(component.isOpen).toBe(false);
+    expect(component.isClosing).toBe(false);
+  });
+
+  it('should auto-close on route navigation', () => {
+    openPalette();
+    const router = TestBed.inject(Router);
+    router.navigateByUrl('/somewhere');
+    fixture.detectChanges();
+    expect(component.isClosing).toBe(true);
+  });
+
+  // --- Focus Trap ---
+
+  it('should prevent Tab from leaving the palette', () => {
+    openPalette();
+    const event = new KeyboardEvent('keydown', { key: 'Tab' });
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+    component.onKeydown(event);
+    expect(preventSpy).toHaveBeenCalled();
+  });
+
+  // --- Accessibility ---
+
+  it('should have correct ARIA attributes when open', () => {
+    registry.register(makeCommand('a', 'Test'));
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('a');
+    openPalette();
+
+    const dialog = getElement('[role="dialog"]');
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    expect(dialog?.getAttribute('aria-label')).toBe('Command palette');
+
+    const input = getElement('[role="combobox"]');
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute('aria-controls')).toBe('palette-listbox');
+    expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+
+    const listbox = getElement('[role="listbox"]');
+    expect(listbox).toBeTruthy();
+
+    const options = fixture.nativeElement.querySelectorAll('[role="option"]');
+    expect(options.length).toBeGreaterThan(0);
+
+    const liveRegion = getElement('[aria-live="polite"]');
+    expect(liveRegion).toBeTruthy();
+  });
+
+  it('should have aria-activedescendant pointing to selected item', () => {
+    registry.register(makeCommand('a', 'Test'));
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('a');
+    openPalette();
+
+    const input = getElement('[role="combobox"]');
+    expect(input?.getAttribute('aria-activedescendant')).toBe('palette-item-0');
+  });
+
+  it('should set aria-expanded based on displayed items', () => {
+    openPalette(); // no commands
+    const input = getElement('[role="combobox"]');
+    expect(input?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should have maxlength 120 on input', () => {
+    openPalette();
+    const input = getElement('.palette-input') as HTMLInputElement;
+    expect(input.maxLength).toBe(120);
+  });
+
+  // --- Result count announcement ---
+
+  it('should announce result count in aria-live region', () => {
+    registry.register(makeCommand('a', 'Alpha'));
+    registry.register(makeCommand('b', 'Beta'));
+    openPalette();
+
+    simulateInput('Alpha');
+    vi.advanceTimersByTime(100);
+    fixture.detectChanges();
+
+    expect(component.resultCountAnnouncement).toContain('1 result');
+  });
+
+  it('should announce "No results found" for zero results', () => {
+    registry.register(makeCommand('a', 'Alpha'));
+    openPalette();
+
+    simulateInput('zzzzz');
+    vi.advanceTimersByTime(100);
+    fixture.detectChanges();
+
+    expect(component.resultCountAnnouncement).toBe('No results found');
+  });
+
+  // --- Recent items header ---
+
+  it('should show Recent header when displaying recent items', () => {
+    registry.register(makeCommand('a', 'Alpha'));
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('a');
+    openPalette();
+
+    expect(getElement('.palette-section-header')?.textContent).toContain('Recent');
+  });
+
+  // --- Category badges ---
+
+  it('should display category badges', () => {
+    registry.register(makeCommand('a', 'Alpha', [], 'navigation'));
+    registry.register(makeCommand('b', 'Beta', [], 'action'));
+    const recentService = TestBed.inject(RecentCommandsService);
+    recentService.pushRecent('b');
+    recentService.pushRecent('a');
+    openPalette();
+
+    const categories = fixture.nativeElement.querySelectorAll('.palette-item-category');
+    expect(categories.length).toBe(2);
+    const texts = Array.from(categories).map((el: any) => el.textContent.trim());
+    expect(texts).toContain('Navigation');
+    expect(texts).toContain('Action');
+  });
+});

--- a/src/app/command-palette/command-palette.component.ts
+++ b/src/app/command-palette/command-palette.component.ts
@@ -1,0 +1,532 @@
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, NavigationStart } from '@angular/router';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, filter } from 'rxjs/operators';
+import { Command } from './command.model';
+import { CommandRegistryService } from './command-registry.service';
+import { FuzzySearchService } from './fuzzy-search.service';
+import { RecentCommandsService } from './recent-commands.service';
+import { AnalyticsService } from '../shared/analytics.service';
+
+@Component({
+  selector: 'app-command-palette',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (isOpen) {
+      <div
+        class="palette-backdrop"
+        [class.palette-closing]="isClosing"
+        (click)="dismissViaClickOutside()"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="palette-container"
+        [class.palette-closing]="isClosing"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        (animationend)="onAnimationEnd()"
+      >
+        <div class="palette-content" (click)="$event.stopPropagation()">
+          <input
+            #searchInput
+            class="palette-input"
+            type="text"
+            role="combobox"
+            [attr.aria-expanded]="displayedItems.length > 0"
+            aria-controls="palette-listbox"
+            [attr.aria-activedescendant]="displayedItems.length > 0 ? 'palette-item-' + selectedIndex : null"
+            aria-autocomplete="list"
+            placeholder="Type a command or search\u2026"
+            [maxLength]="120"
+            [value]="query"
+            (input)="onInput($event)"
+            (keydown)="onKeydown($event)"
+          />
+          <div aria-live="polite" class="sr-only">
+            {{ resultCountAnnouncement }}
+          </div>
+          <div
+            id="palette-listbox"
+            role="listbox"
+            class="palette-results"
+            aria-label="Command results"
+          >
+            @if (showRecentHeader && !query && recentItems.length > 0) {
+              <div class="palette-section-header">Recent</div>
+            }
+            @if (displayedItems.length === 0 && !query && allCommands.length === 0) {
+              <div class="palette-empty">No commands available</div>
+            }
+            @if (displayedItems.length === 0 && query) {
+              <div class="palette-empty">No results for '{{ query }}' &mdash; Try a different keyword</div>
+            }
+            @for (item of displayedItems; track item.id; let i = $index) {
+              <div
+                [id]="'palette-item-' + i"
+                role="option"
+                class="palette-item"
+                [class.palette-item-selected]="i === selectedIndex"
+                [attr.aria-selected]="i === selectedIndex"
+                (mouseenter)="onMouseEnter(i)"
+                (click)="executeCommand(item)"
+              >
+                @if (item.icon) {
+                  <span class="palette-item-icon" aria-hidden="true">{{ item.icon }}</span>
+                }
+                <span class="palette-item-label">{{ item.label }}</span>
+                <span
+                  class="palette-item-category"
+                  [class.category-navigation]="item.category === 'navigation'"
+                  [class.category-action]="item.category === 'action'"
+                >{{ item.category === 'navigation' ? 'Navigation' : 'Action' }}</span>
+                @if (item.shortcutHint) {
+                  <span class="palette-item-shortcut">{{ item.shortcutHint }}</span>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    }
+  `,
+  styles: [`
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .palette-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.4);
+      z-index: 9998;
+      animation: fadeIn 150ms ease-out forwards;
+    }
+    .palette-backdrop.palette-closing {
+      animation: fadeOut 150ms ease-out forwards;
+    }
+
+    .palette-container {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      padding-top: 15vh;
+      pointer-events: none;
+      animation: paletteOpen 150ms ease-out forwards;
+      will-change: transform, opacity;
+    }
+    .palette-container.palette-closing {
+      animation: paletteClose 150ms ease-out forwards;
+    }
+
+    .palette-content {
+      pointer-events: auto;
+      width: 100%;
+      max-width: 640px;
+      margin: 0 16px;
+      background: var(--palette-bg, #ffffff);
+      border: 1px solid var(--palette-border, #e2e8f0);
+      border-radius: 12px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15), 0 4px 16px rgba(0, 0, 0, 0.08);
+      overflow: hidden;
+    }
+
+    .palette-input {
+      width: 100%;
+      padding: 16px 20px;
+      border: none;
+      outline: none;
+      font-size: 16px;
+      background: transparent;
+      color: var(--palette-text, #1a202c);
+      border-bottom: 1px solid var(--palette-border, #e2e8f0);
+      box-sizing: border-box;
+    }
+    .palette-input::placeholder {
+      color: var(--palette-muted, #a0aec0);
+    }
+
+    .palette-results {
+      max-height: 360px;
+      overflow-y: auto;
+      padding: 8px 0;
+    }
+
+    .palette-section-header {
+      padding: 8px 20px 4px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--palette-muted, #a0aec0);
+    }
+
+    .palette-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 20px;
+      cursor: pointer;
+      min-height: 44px;
+      box-sizing: border-box;
+      color: var(--palette-text, #1a202c);
+    }
+    .palette-item:hover,
+    .palette-item-selected {
+      background: var(--palette-highlight, #edf2f7);
+    }
+
+    .palette-item-icon {
+      flex-shrink: 0;
+      width: 20px;
+      text-align: center;
+    }
+
+    .palette-item-label {
+      flex: 1;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .palette-item-category {
+      flex-shrink: 0;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 9999px;
+    }
+    .category-navigation {
+      background: var(--badge-nav-bg, #ebf8ff);
+      color: var(--badge-nav-text, #2b6cb0);
+    }
+    .category-action {
+      background: var(--badge-action-bg, #fffbeb);
+      color: var(--badge-action-text, #b7791f);
+    }
+
+    .palette-item-shortcut {
+      flex-shrink: 0;
+      font-size: 12px;
+      font-family: monospace;
+      color: var(--palette-muted, #a0aec0);
+      padding: 2px 6px;
+      background: var(--palette-shortcut-bg, #f7fafc);
+      border-radius: 4px;
+      border: 1px solid var(--palette-border, #e2e8f0);
+    }
+
+    .palette-empty {
+      padding: 24px 20px;
+      text-align: center;
+      font-size: 14px;
+      color: var(--palette-muted, #a0aec0);
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    @keyframes fadeOut {
+      from { opacity: 1; }
+      to { opacity: 0; }
+    }
+    @keyframes paletteOpen {
+      from {
+        opacity: 0;
+        transform: scale(0.95);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+    @keyframes paletteClose {
+      from {
+        opacity: 1;
+        transform: scale(1);
+      }
+      to {
+        opacity: 0;
+        transform: scale(0.95);
+      }
+    }
+
+    @media screen and (max-width: 640px) {
+      .palette-container {
+        padding-top: 0;
+        align-items: flex-start;
+      }
+      .palette-content {
+        max-width: 100%;
+        margin: 0;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        border-top: none;
+      }
+      .palette-item {
+        min-height: 44px;
+        padding: 12px 20px;
+      }
+    }
+  `]
+})
+export class CommandPaletteComponent implements OnInit, OnDestroy {
+  private registry = inject(CommandRegistryService);
+  private fuzzySearch = inject(FuzzySearchService);
+  private recentService = inject(RecentCommandsService);
+  private analytics = inject(AnalyticsService);
+  private router = inject(Router);
+
+  @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
+
+  isOpen = false;
+  isClosing = false;
+  query = '';
+  selectedIndex = 0;
+  displayedItems: Command[] = [];
+  recentItems: Command[] = [];
+  allCommands: Command[] = [];
+  showRecentHeader = true;
+  resultCountAnnouncement = '';
+
+  private querySubject = new Subject<string>();
+  private querySequence = 0;
+  private subscriptions: Subscription[] = [];
+  private openTimestamp = 0;
+  private previousActiveElement: Element | null = null;
+  private pendingClose = false;
+
+  ngOnInit(): void {
+    const querySub = this.querySubject.pipe(
+      debounceTime(100)
+    ).subscribe(query => {
+      // Discard stale debounced results if query was cleared in the meantime
+      if (this.query === query) {
+        this.performSearch(query);
+      }
+    });
+    this.subscriptions.push(querySub);
+
+    const routerSub = this.router.events.pipe(
+      filter((event): event is NavigationStart => event instanceof NavigationStart)
+    ).subscribe(() => {
+      if (this.isOpen && !this.isClosing) {
+        this.analytics.track('command_palette_dismissed', {
+          had_query: this.query.length > 0,
+          dismiss_method: 'route_change',
+        });
+        this.closeWithAnimation();
+      }
+    });
+    this.subscriptions.push(routerSub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(s => s.unsubscribe());
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent): void {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+      event.preventDefault();
+      if (this.isOpen) {
+        // Idempotent: clear query and refocus
+        this.query = '';
+        this.loadRecentItems();
+        this.displayedItems = this.recentItems;
+        this.selectedIndex = this.displayedItems.length > 0 ? 0 : -1;
+        this.announceResultCount();
+        setTimeout(() => {
+          this.searchInput?.nativeElement?.focus();
+        });
+      } else {
+        this.open('keyboard');
+      }
+    }
+  }
+
+  open(triggerMethod: 'keyboard' | 'ui'): void {
+    if (this.isOpen || this.isClosing) {
+      return; // Guard against rapid toggling
+    }
+    // TODO: SSR guard
+    this.previousActiveElement = document.activeElement;
+    this.openTimestamp = Date.now();
+    this.isOpen = true;
+    this.isClosing = false;
+    this.query = '';
+    this.allCommands = this.registry.getAll();
+    this.loadRecentItems();
+    this.displayedItems = this.recentItems;
+    this.selectedIndex = this.displayedItems.length > 0 ? 0 : -1;
+    this.announceResultCount();
+
+    this.analytics.track('command_palette_opened', { trigger_method: triggerMethod });
+
+    setTimeout(() => {
+      this.searchInput?.nativeElement?.focus();
+    });
+  }
+
+  onInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.query = value;
+    // Increment sequence to invalidate any pending debounced search
+    this.querySequence++;
+    if (!value.trim()) {
+      this.displayedItems = this.recentItems;
+      this.selectedIndex = this.displayedItems.length > 0 ? 0 : -1;
+      this.showRecentHeader = true;
+      this.announceResultCount();
+    } else {
+      this.showRecentHeader = false;
+      this.querySubject.next(value);
+    }
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (this.displayedItems.length > 0) {
+        this.selectedIndex = (this.selectedIndex + 1) % this.displayedItems.length;
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (this.displayedItems.length > 0) {
+        this.selectedIndex = (this.selectedIndex - 1 + this.displayedItems.length) % this.displayedItems.length;
+      }
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      if (this.selectedIndex >= 0 && this.selectedIndex < this.displayedItems.length) {
+        this.executeCommand(this.displayedItems[this.selectedIndex]);
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      this.dismiss('escape');
+    } else if (event.key === 'Tab') {
+      // Focus trap: prevent Tab and Shift+Tab from leaving the palette
+      event.preventDefault();
+    }
+  }
+
+  onMouseEnter(index: number): void {
+    this.selectedIndex = index;
+  }
+
+  executeCommand(command: Command): void {
+    const durationMs = Date.now() - this.openTimestamp;
+    try {
+      // Apply theme change before closing animation to prevent visual flash
+      command.execute();
+    } catch (error) {
+      console.error(`Command execution failed for '${command.id}':`, error);
+    }
+
+    this.recentService.pushRecent(command.id);
+
+    this.analytics.track('command_palette_executed', {
+      command_id: command.id,
+      command_category: command.category,
+      query_text: this.query,
+      duration_ms: durationMs,
+    });
+
+    this.closeWithAnimation();
+  }
+
+  dismissViaClickOutside(): void {
+    this.dismiss('click_outside');
+  }
+
+  private dismiss(method: 'escape' | 'click_outside'): void {
+    this.analytics.track('command_palette_dismissed', {
+      had_query: this.query.length > 0,
+      dismiss_method: method,
+    });
+    this.closeWithAnimation();
+  }
+
+  private closeWithAnimation(): void {
+    if (this.isClosing) {
+      return;
+    }
+    this.isClosing = true;
+    this.pendingClose = true;
+  }
+
+  onAnimationEnd(): void {
+    if (this.pendingClose) {
+      this.isOpen = false;
+      this.isClosing = false;
+      this.pendingClose = false;
+      this.restoreFocus();
+    }
+  }
+
+  private restoreFocus(): void {
+    // TODO: SSR guard
+    if (this.previousActiveElement && this.previousActiveElement instanceof HTMLElement) {
+      this.previousActiveElement.focus();
+    }
+    this.previousActiveElement = null;
+  }
+
+  private loadRecentItems(): void {
+    if (this.recentService.isStorageAvailable()) {
+      this.recentItems = this.recentService.getRecent();
+      this.showRecentHeader = true;
+    } else {
+      this.recentItems = [];
+      this.showRecentHeader = false;
+    }
+  }
+
+  private performSearch(query: string): void {
+    this.allCommands = this.registry.getAll();
+    const results = this.fuzzySearch.search(query, this.allCommands);
+
+    this.displayedItems = results.map(r => r.command);
+    this.selectedIndex = this.displayedItems.length > 0 ? 0 : -1;
+    this.announceResultCount();
+
+    if (this.displayedItems.length === 0 && query.trim()) {
+      this.analytics.track('command_palette_no_results', { query_text: query });
+    }
+  }
+
+  private announceResultCount(): void {
+    if (this.query) {
+      this.resultCountAnnouncement =
+        this.displayedItems.length === 0
+          ? 'No results found'
+          : `${this.displayedItems.length} result${this.displayedItems.length === 1 ? '' : 's'} available`;
+    } else {
+      this.resultCountAnnouncement =
+        this.recentItems.length > 0
+          ? `${this.recentItems.length} recent item${this.recentItems.length === 1 ? '' : 's'}`
+          : '';
+    }
+  }
+}

--- a/src/app/command-palette/command-registry.service.spec.ts
+++ b/src/app/command-palette/command-registry.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { CommandRegistryService } from './command-registry.service';
+import { Command } from './command.model';
+
+describe('CommandRegistryService', () => {
+  let service: CommandRegistryService;
+
+  const makeCommand = (id: string, label = 'Test'): Command => ({
+    id,
+    label,
+    category: 'navigation',
+    keywords: [],
+    execute: () => {},
+  });
+
+  beforeEach(() => {
+    service = TestBed.inject(CommandRegistryService);
+  });
+
+  it('should register and retrieve a command', () => {
+    const cmd = makeCommand('test');
+    service.register(cmd);
+    expect(service.getById('test')).toBe(cmd);
+  });
+
+  it('should return all registered commands', () => {
+    service.register(makeCommand('a'));
+    service.register(makeCommand('b'));
+    expect(service.getAll().length).toBe(2);
+  });
+
+  it('should return undefined for unknown id', () => {
+    expect(service.getById('nonexistent')).toBeUndefined();
+  });
+
+  it('should unregister a command', () => {
+    service.register(makeCommand('a'));
+    service.unregister('a');
+    expect(service.getById('a')).toBeUndefined();
+    expect(service.getAll().length).toBe(0);
+  });
+
+  it('should overwrite command with same id', () => {
+    service.register(makeCommand('a', 'First'));
+    service.register(makeCommand('a', 'Second'));
+    expect(service.getById('a')!.label).toBe('Second');
+    expect(service.getAll().length).toBe(1);
+  });
+
+  it('should return empty array when no commands registered', () => {
+    expect(service.getAll()).toEqual([]);
+  });
+});

--- a/src/app/command-palette/command-registry.service.ts
+++ b/src/app/command-palette/command-registry.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Command } from './command.model';
+
+@Injectable({ providedIn: 'root' })
+export class CommandRegistryService {
+  private commands = new Map<string, Command>();
+
+  register(cmd: Command): void {
+    this.commands.set(cmd.id, cmd);
+  }
+
+  unregister(id: string): void {
+    this.commands.delete(id);
+  }
+
+  getAll(): Command[] {
+    return Array.from(this.commands.values());
+  }
+
+  getById(id: string): Command | undefined {
+    return this.commands.get(id);
+  }
+}

--- a/src/app/command-palette/command.model.ts
+++ b/src/app/command-palette/command.model.ts
@@ -1,0 +1,14 @@
+export interface Command {
+  id: string;
+  label: string;
+  category: 'navigation' | 'action';
+  icon?: string;
+  shortcutHint?: string;
+  keywords: string[];
+  execute: () => void;
+}
+
+export interface ScoredCommand {
+  command: Command;
+  score: number;
+}

--- a/src/app/command-palette/commands.initializer.ts
+++ b/src/app/command-palette/commands.initializer.ts
@@ -1,0 +1,63 @@
+import { ENVIRONMENT_INITIALIZER, inject, makeEnvironmentProviders } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommandRegistryService } from './command-registry.service';
+import { ThemeService } from '../shared/theme.service';
+
+export function provideDefaultCommands() {
+  return makeEnvironmentProviders([
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      multi: true,
+      useValue: () => {
+        const registry = inject(CommandRegistryService);
+        const router = inject(Router);
+        const themeService = inject(ThemeService);
+
+        registry.register({
+          id: 'nav:dashboard',
+          label: 'Go to Dashboard',
+          category: 'navigation',
+          icon: '\u{1F3E0}',
+          keywords: ['home', 'main'],
+          execute: () => { router.navigate(['/dashboard']); },
+        });
+
+        registry.register({
+          id: 'nav:profile',
+          label: 'Go to Profile',
+          category: 'navigation',
+          icon: '\u{1F464}',
+          keywords: ['account', 'user'],
+          execute: () => { router.navigate(['/profile']); },
+        });
+
+        registry.register({
+          id: 'nav:settings',
+          label: 'Go to Settings',
+          category: 'navigation',
+          icon: '\u2699\uFE0F',
+          keywords: ['preferences', 'config', 'configuration'],
+          execute: () => { router.navigate(['/settings']); },
+        });
+
+        registry.register({
+          id: 'nav:help',
+          label: 'Go to Help',
+          category: 'navigation',
+          icon: '\u2753',
+          keywords: ['support', 'docs', 'documentation', 'faq'],
+          execute: () => { router.navigate(['/help']); },
+        });
+
+        registry.register({
+          id: 'action:dark-mode',
+          label: 'Toggle Dark Mode',
+          category: 'action',
+          icon: '\u{1F31C}',
+          keywords: ['theme', 'light', 'dark', 'appearance'],
+          execute: () => { themeService.toggle(); },
+        });
+      },
+    },
+  ]);
+}

--- a/src/app/command-palette/fuzzy-search.service.spec.ts
+++ b/src/app/command-palette/fuzzy-search.service.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { FuzzySearchService } from './fuzzy-search.service';
+import { Command } from './command.model';
+
+describe('FuzzySearchService', () => {
+  let service: FuzzySearchService;
+
+  const makeCommand = (id: string, label: string, keywords: string[] = []): Command => ({
+    id,
+    label,
+    category: 'navigation',
+    keywords,
+    execute: () => {},
+  });
+
+  const commands: Command[] = [
+    makeCommand('nav:dashboard', 'Go to Dashboard', ['home', 'main']),
+    makeCommand('nav:profile', 'Go to Profile', ['account', 'user']),
+    makeCommand('nav:settings', 'Go to Settings', ['preferences', 'config', 'configuration']),
+    makeCommand('nav:help', 'Go to Help', ['support', 'docs', 'documentation', 'faq']),
+    makeCommand('action:dark-mode', 'Toggle Dark Mode', ['theme', 'light', 'dark', 'appearance']),
+  ];
+
+  beforeEach(() => {
+    service = TestBed.inject(FuzzySearchService);
+  });
+
+  it('should return empty array for empty query', () => {
+    expect(service.search('', commands)).toEqual([]);
+  });
+
+  it('should return empty array for whitespace-only query', () => {
+    expect(service.search('   ', commands)).toEqual([]);
+  });
+
+  it('should find exact label match', () => {
+    const results = service.search('Go to Dashboard', commands);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].command.id).toBe('nav:dashboard');
+  });
+
+  it('should find partial label match', () => {
+    const results = service.search('Dashboard', commands);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].command.id).toBe('nav:dashboard');
+  });
+
+  it('should match against keywords', () => {
+    const results = service.search('preferences', commands);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].command.id).toBe('nav:settings');
+  });
+
+  it('should match misspelled/partial queries (fuzzy)', () => {
+    const results = service.search('drk mod', commands);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some(r => r.command.id === 'action:dark-mode')).toBe(true);
+  });
+
+  it('should be case insensitive', () => {
+    const results = service.search('DASHBOARD', commands);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].command.id).toBe('nav:dashboard');
+  });
+
+  it('should return zero results for non-matching query', () => {
+    const results = service.search('xyznonexistent', commands);
+    expect(results.length).toBe(0);
+  });
+
+  it('should sort results by score descending', () => {
+    const results = service.search('Go to', commands);
+    expect(results.length).toBe(4); // all nav commands
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it('should cap results at 20', () => {
+    const manyCommands: Command[] = [];
+    for (let i = 0; i < 30; i++) {
+      manyCommands.push(makeCommand(`cmd-${i}`, `Command ${i}`, ['test']));
+    }
+    const results = service.search('Command', manyCommands);
+    expect(results.length).toBeLessThanOrEqual(20);
+  });
+
+  it('should only return results with score > 0', () => {
+    const results = service.search('dash', commands);
+    for (const r of results) {
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  it('should give prefix matches higher scores', () => {
+    const cmds = [
+      makeCommand('a', 'settings page', []),
+      makeCommand('b', 'Go to Settings', ['settings']),
+    ];
+    const results = service.search('settings', cmds);
+    expect(results.length).toBe(2);
+    // The one where 'settings' is a prefix of label should score higher
+    expect(results[0].command.id).toBe('a');
+  });
+
+  it('should search empty command list', () => {
+    expect(service.search('test', [])).toEqual([]);
+  });
+});

--- a/src/app/command-palette/fuzzy-search.service.ts
+++ b/src/app/command-palette/fuzzy-search.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { Command, ScoredCommand } from './command.model';
+
+const MAX_RESULTS = 20;
+
+@Injectable({ providedIn: 'root' })
+export class FuzzySearchService {
+  // TODO: Add category-scoped search prefixes (> for actions, / for navigation)
+
+  search(query: string, commands: Command[]): ScoredCommand[] {
+    if (!query.trim()) {
+      return [];
+    }
+
+    const lowerQuery = query.toLowerCase();
+
+    const scored: ScoredCommand[] = [];
+    for (const command of commands) {
+      const labelScore = this.score(lowerQuery, command.label.toLowerCase());
+      let bestKeywordScore = 0;
+      for (const kw of command.keywords) {
+        const kwScore = this.score(lowerQuery, kw.toLowerCase());
+        if (kwScore > bestKeywordScore) {
+          bestKeywordScore = kwScore;
+        }
+      }
+      const finalScore = Math.max(labelScore, bestKeywordScore * 0.9);
+      if (finalScore > 0) {
+        scored.push({ command, score: finalScore });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, MAX_RESULTS);
+  }
+
+  /**
+   * Lightweight consecutive-character fuzzy scorer.
+   * Bonuses: consecutive matches, prefix match, exact case match.
+   */
+  private score(query: string, target: string): number {
+    if (target.includes(query)) {
+      // Substring match — high score with prefix bonus
+      const prefixBonus = target.startsWith(query) ? 50 : 0;
+      return 100 + prefixBonus + (query.length / target.length) * 50;
+    }
+
+    let score = 0;
+    let queryIdx = 0;
+    let consecutive = 0;
+    let firstMatchBonus = 0;
+
+    for (let i = 0; i < target.length && queryIdx < query.length; i++) {
+      if (target[i] === query[queryIdx]) {
+        queryIdx++;
+        consecutive++;
+        score += 10 + consecutive * 5;
+        if (i === 0 && queryIdx === 1) {
+          firstMatchBonus = 20;
+        }
+      } else {
+        consecutive = 0;
+      }
+    }
+
+    if (queryIdx < query.length) {
+      return 0; // Not all query characters found
+    }
+
+    return score + firstMatchBonus;
+  }
+}

--- a/src/app/command-palette/recent-commands.service.spec.ts
+++ b/src/app/command-palette/recent-commands.service.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@angular/core/testing';
+import { RecentCommandsService } from './recent-commands.service';
+import { CommandRegistryService } from './command-registry.service';
+import { Command } from './command.model';
+
+describe('RecentCommandsService', () => {
+  let service: RecentCommandsService;
+  let registry: CommandRegistryService;
+
+  const makeCommand = (id: string): Command => ({
+    id,
+    label: `Command ${id}`,
+    category: 'navigation',
+    keywords: [],
+    execute: () => {},
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    registry = TestBed.inject(CommandRegistryService);
+    service = TestBed.inject(RecentCommandsService);
+  });
+
+  it('should return empty recent list initially', () => {
+    expect(service.getRecent()).toEqual([]);
+  });
+
+  it('should push and retrieve recent command', () => {
+    registry.register(makeCommand('a'));
+    service.pushRecent('a');
+    const recent = service.getRecent();
+    expect(recent.length).toBe(1);
+    expect(recent[0].id).toBe('a');
+  });
+
+  it('should deduplicate: most recent first', () => {
+    registry.register(makeCommand('a'));
+    registry.register(makeCommand('b'));
+    service.pushRecent('a');
+    service.pushRecent('b');
+    service.pushRecent('a');
+    const recent = service.getRecent();
+    expect(recent.length).toBe(2);
+    expect(recent[0].id).toBe('a');
+    expect(recent[1].id).toBe('b');
+  });
+
+  it('should cap at 5 items', () => {
+    for (let i = 0; i < 7; i++) {
+      registry.register(makeCommand(`cmd-${i}`));
+      service.pushRecent(`cmd-${i}`);
+    }
+    expect(service.getRecent().length).toBe(5);
+  });
+
+  it('should silently drop stale IDs not in registry', () => {
+    registry.register(makeCommand('a'));
+    service.pushRecent('a');
+    service.pushRecent('stale-id');
+    registry.unregister('a');
+    expect(service.getRecent()).toEqual([]);
+  });
+
+  it('should report storage available', () => {
+    expect(service.isStorageAvailable()).toBe(true);
+  });
+
+  it('should handle corrupted localStorage data gracefully', () => {
+    localStorage.setItem('command_palette_recent', '{invalid json[');
+    registry.register(makeCommand('a'));
+    expect(service.getRecent()).toEqual([]);
+  });
+
+  it('should handle non-array localStorage data', () => {
+    localStorage.setItem('command_palette_recent', '"just a string"');
+    expect(service.getRecent()).toEqual([]);
+  });
+
+  it('should filter non-string items from localStorage', () => {
+    localStorage.setItem('command_palette_recent', JSON.stringify(['a', 123, null, 'b']));
+    registry.register(makeCommand('a'));
+    registry.register(makeCommand('b'));
+    const recent = service.getRecent();
+    expect(recent.length).toBe(2);
+  });
+});
+
+describe('RecentCommandsService (storage unavailable)', () => {
+  let service: RecentCommandsService;
+
+  beforeEach(() => {
+    // Make localStorage throw
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => {
+      if (key === '__storage_test__') {
+        throw new Error('storage disabled');
+      }
+      return originalSetItem.call(localStorage, key, value);
+    });
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RecentCommandsService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should report storage unavailable', () => {
+    expect(service.isStorageAvailable()).toBe(false);
+  });
+
+  it('should return empty recent list when storage unavailable', () => {
+    expect(service.getRecent()).toEqual([]);
+  });
+});

--- a/src/app/command-palette/recent-commands.service.ts
+++ b/src/app/command-palette/recent-commands.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, inject } from '@angular/core';
+import { Command } from './command.model';
+import { CommandRegistryService } from './command-registry.service';
+
+const STORAGE_KEY = 'command_palette_recent';
+const MAX_RECENT = 5;
+
+@Injectable({ providedIn: 'root' })
+export class RecentCommandsService {
+  private registry = inject(CommandRegistryService);
+  private storageAvailable = true;
+
+  constructor() {
+    // TODO: SSR guard
+    try {
+      const test = '__storage_test__';
+      localStorage.setItem(test, test);
+      localStorage.removeItem(test);
+    } catch {
+      this.storageAvailable = false;
+    }
+  }
+
+  isStorageAvailable(): boolean {
+    return this.storageAvailable;
+  }
+
+  getRecent(): Command[] {
+    const ids = this.loadIds();
+    const commands: Command[] = [];
+    const validIds: string[] = [];
+
+    for (const id of ids) {
+      const cmd = this.registry.getById(id);
+      if (cmd) {
+        commands.push(cmd);
+        validIds.push(id);
+      }
+      // Silently drop stale IDs
+    }
+
+    // Clean up stale IDs in storage
+    if (validIds.length !== ids.length) {
+      this.saveIds(validIds);
+    }
+
+    return commands;
+  }
+
+  pushRecent(id: string): void {
+    const ids = this.loadIds().filter(existingId => existingId !== id);
+    ids.unshift(id);
+    this.saveIds(ids.slice(0, MAX_RECENT));
+  }
+
+  private loadIds(): string[] {
+    if (!this.storageAvailable) {
+      return [];
+    }
+    // TODO: SSR guard
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((item): item is string => typeof item === 'string');
+        }
+      }
+    } catch {
+      // Corrupted data or private browsing — ignore
+    }
+    return [];
+  }
+
+  private saveIds(ids: string[]): void {
+    if (!this.storageAvailable) {
+      return;
+    }
+    // TODO: SSR guard
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    } catch {
+      // Quota exceeded — ignore
+    }
+  }
+}

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  template: `<div class="page"><h1>Dashboard</h1><p>Welcome to the dashboard.</p></div>`,
+  styles: [`.page { padding: 24px; }`],
+})
+export class DashboardComponent {}

--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-help',
+  standalone: true,
+  template: `<div class="page"><h1>Help</h1><p>Help and documentation.</p></div>`,
+  styles: [`.page { padding: 24px; }`],
+})
+export class HelpComponent {}

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  template: `<div class="page"><h1>Profile</h1><p>Your profile page.</p></div>`,
+  styles: [`.page { padding: 24px; }`],
+})
+export class ProfileComponent {}

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  standalone: true,
+  template: `<div class="page"><h1>Settings</h1><p>Application settings.</p></div>`,
+  styles: [`.page { padding: 24px; }`],
+})
+export class SettingsComponent {}

--- a/src/app/shared/analytics.service.spec.ts
+++ b/src/app/shared/analytics.service.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(() => {
+    service = TestBed.inject(AnalyticsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should call console.debug on track', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    service.track('test_event', { key: 'value' });
+    expect(spy).toHaveBeenCalledWith('[Analytics] test_event', { key: 'value' });
+    spy.mockRestore();
+  });
+});

--- a/src/app/shared/analytics.service.ts
+++ b/src/app/shared/analytics.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AnalyticsService {
+  track(eventName: string, properties: Record<string, unknown>): void {
+    // TODO: Replace with real analytics provider (Segment, Amplitude, etc.)
+    console.debug(`[Analytics] ${eventName}`, properties);
+  }
+}

--- a/src/app/shared/theme.service.spec.ts
+++ b/src/app/shared/theme.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('should default to light theme', () => {
+    const service = TestBed.inject(ThemeService);
+    expect(service.theme()).toBe('light');
+  });
+
+  it('should set data-theme attribute on document', () => {
+    TestBed.inject(ThemeService);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('should toggle to dark then back to light', () => {
+    const service = TestBed.inject(ThemeService);
+    service.toggle();
+    expect(service.theme()).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    service.toggle();
+    expect(service.theme()).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('should persist theme to localStorage', () => {
+    const service = TestBed.inject(ThemeService);
+    service.toggle();
+    expect(localStorage.getItem('app_theme')).toBe('dark');
+  });
+
+  it('should load persisted theme from localStorage', () => {
+    localStorage.setItem('app_theme', 'dark');
+    const service = TestBed.inject(ThemeService);
+    expect(service.theme()).toBe('dark');
+  });
+
+  it('should default to light for invalid stored value', () => {
+    localStorage.setItem('app_theme', 'invalid');
+    const service = TestBed.inject(ThemeService);
+    expect(service.theme()).toBe('light');
+  });
+});

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly theme = signal<'light' | 'dark'>(this.loadTheme());
+
+  toggle(): void {
+    const next = this.theme() === 'light' ? 'dark' : 'light';
+    this.theme.set(next);
+    this.applyTheme(next);
+    this.persistTheme(next);
+  }
+
+  /** Apply on construction so the theme is set at startup. */
+  constructor() {
+    this.applyTheme(this.theme());
+  }
+
+  private applyTheme(value: 'light' | 'dark'): void {
+    // TODO: SSR guard — wrap with isPlatformBrowser if SSR is adopted
+    document.documentElement.setAttribute('data-theme', value);
+  }
+
+  private loadTheme(): 'light' | 'dark' {
+    // TODO: SSR guard
+    try {
+      const stored = localStorage.getItem('app_theme');
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+    } catch {
+      // Private browsing or quota exceeded — default to light
+    }
+    return 'light';
+  }
+
+  private persistTheme(value: 'light' | 'dark'): void {
+    // TODO: SSR guard
+    try {
+      localStorage.setItem('app_theme', value);
+    } catch {
+      // Private browsing or quota exceeded — ignore
+    }
+  }
+}


### PR DESCRIPTION
## ⚠️ Pipeline Failed

**Reason:** Pipeline failed after 2 loop(s). Tests are FAILING.

### Test Failures
```
Test failed (`npx ng test --watch=false`):
[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                                  [2m | [22m[1mNames[22m                                             [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                                      [2m | [22m[2mspec-app-app[22m                                      [2m | [22m [36m48.87 kB[39m[2m | [22m
[32mchunk-FWNUXTYQ.js[39m                                    [2m | [22m[2m-[22m                                                 [2m | [22m [36m28.88 kB[39m[2m | [22m
[32mspec-app-command-palette-command-palette.component.js[39m[2m | [22m[2mspec-app-command-palette-command-palette.component[22m[2m | [22m [36m12.92 kB[39m[2m | [22m
[32mchunk-CGZBV6BD.js[39m                                    [2m | [22m[2m-[22m                                                 [2m | [22m  [36m4.07 kB[39m[2m | [22m
[32mspec-app-command-palette-fuzzy-search.service.js[39m     [2m | [22m[2mspec-app-command-palette-fuzzy-search.service[22m     [2m | [22m  [36m3.76 kB[39m[2m | [22m
[32mspec-app-command-palette-recent-commands.service.js[39m  [2m | [22m[2mspec-app-command-palette-recent-commands.service[22m  [2m | [22m  [36m3.59 kB[39m[2m | [22m
[32mspec-app-shared-theme.service.js[39m                     [2m | [22m[2mspec-app-shared-theme.service[22m                     [2m | [22m  [36m3.12 kB[39m[2m | [22m
… (truncated)
```

### Diagnostic
Pipeline exhausted after 2 review loop(s).

### Test Failures
```
Test failed (`npx ng test --watch=false`):
[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                                  [2m | [22m[1mNames[22m                                             [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                                      [2m | [22m[2mspec-app-app[22m                                      [2m | [22m [36m48.87 kB[39m[2m | [22m
[32mchunk-FWNUXTYQ.js[39m                                    [2m | [22m[2m-[22m                                                 [2m | [22m [36m28.88 kB[39m[2m | [22m
[32mspec-app-command-palette-command-palette.component.js[39m[2m | [22m[2mspec-app-command-palette-command-palette.component[22m[2m | [22m [36m12.92 kB[39m[2m | [22m
[32mchunk-CGZBV6BD.js[39m                                    [2m | [22m[2m-[22m                                                 [2m | [22m  [36m4.07 kB[39m[2m | [22m
[32mspec-app-command-palette-fuzzy-search.service.js[39m     [2m | [22m[2mspec-app-command-palette-fuzzy-search.service[22m     [2m | [22m  [36m3.76 kB[39m[2m | [22m
[32mspec-app-command-palette-recent-commands.service.js[39m  [2m | [22m[2mspec-app-command-palette-recent-commands.service[22m  [2m | [22m  [36m3.59 kB[39m[2m | [22m
[32mspec-app-shared-theme.service.js[39m                     [2m | [22m[2mspec-app-shared-theme.service[22m                     [2m | [22m  [36m3.12 kB[39m[2m | [22m
… (truncated)
```

### Recommended Next Steps
- Review the issues above and provide `--guidance` on the next run
- Re-run with the same `branch` input to continue from this code state

### How to Continue

**Option 1:** Comment on this PR:
`/bmad retry Your guidance here`

**Option 2:** Manual dispatch:
```
gh workflow run bmad-start-run.yml \
  -f target_repo="diegosramirez/my-test-app" \
  -f branch="bmad/sam1/SAM1-202-add-a-searchable-command-palette-cmd-k-c" \
  -f prompt="Add a searchable command palette (Cmd+K / Ctrl+K) that lets users quickly navigate to any page (add " \
  -f team_id="SAM1" \
  -f skip_check_epic_state=true \
  -f skip_create_or_correct_epic=true \
  -f skip_create_story_tasks=true \
  -f skip_party_mode_refinement=true \
  -f extra_flags="--story-key SAM1-202 --retry"
```

---
## Story
**SAM1-202**: **Hypothesis**

## Acceptance Criteria
- **Palette Opens via Shortcut and UI Button:** Given the user is on any page, When they press Cmd+K (macOS) / Ctrl+K (Windows/Linux) or click the UI trigger button, Then the command palette overlay appears with smooth animation, the search input is auto-focused, and `command_palette_opened` fires with the correct `trigger_method`. Pressing the shortcut while the palette is already open clears the query and refocuses the input without closing.
- **Fuzzy Search Filters Commands:** Given the palette is open, When the user types a partial or misspelled query (e.g., 'drk mod'), Then relevant commands (e.g., 'Toggle Dark Mode') appear in the filtered results within the 100ms debounce window. When no results match, a 'No results' message is displayed and `command_palette_no_results` fires.
- **Keyboard and Mouse Navigation:** Given search results or recent items are displayed, When the user presses Arrow Down/Up, Then the selection highlight moves accordingly with wrapping at list boundaries. Mouse hover updates the highlight, and subsequent keyboard input moves relative to the hovered item. Enter executes the highlighted command.
- **Command Execution and Recent Items:** Given the user selects and executes a command, When they press Enter, Then the command executes correctly (route navigates or action fires), the palette closes, the command is added to the front of recent items (deduplicated, max 5 in localStorage), and `command_palette_executed` fires including `duration_ms`.
- **Palette Dismissal:** Given the palette is open, When the user presses Escape, clicks outside the palette, or a background route change occurs, Then the palette closes with reverse animation, no command executes, and `command_palette_dismissed` fires with correct `dismiss_method` and `had_query`.
- **Accessibility Compliance (WCAG 2.1 AA):** Given the palette is open, When inspected, Then it has `role='dialog'` with `aria-modal='true'`, input has `role='combobox'` with `aria-activedescendant`, results use `role='listbox'`/`role='option'`, an `aria-live='polite'` region announces result count, focus is trapped inside the palette, and focus restores to the previously focused element on close.
- **Dark Mode Theming:** Given the user executes 'Toggle Dark Mode', Then the application theme toggles between light and dark, the palette respects the current theme via CSS custom properties, and the theme change is applied before or simultaneously with the palette close animation (no visual flash).
- **Responsive and Mobile Behavior:** Given the user is on a mobile viewport (≤640px), When they tap the UI trigger button, Then the palette renders full-width and top-positioned (not vertically centered) with minimum 44×44px touch targets per result row, without conflicting with the on-screen keyboard.

## Implementation Details
### Architecture


# Technical Architecture Review: Command Palette

## Data Model Changes

No backend or database schema changes are required. All data models are client-side only.

**Command Registration Model (`Command`)**

```typescript
interface Command {
  id: string;                          // unique key, e.g. 'nav:settings'
  label: string;                       // display text, e.g. 'Go to Settings'
  category: 'navigation' | 'action';  // used for badge + analytics
  icon?: string;                       // optional icon identifier
  shortcutHint?: string;              // optional display string, e.g

### Developer Notes
**Architecture Overview**

Build as a self-contained `command-palette` module with five core units: `CommandRegistryService`, `FuzzySearchService`, `RecentCommandsService`, `AnalyticsService`, and `CommandPaletteComponent`. Add `ThemeService` in `shared/`. All services are `providedIn: 'root'`. The component is standalone, placed once in `app.ts` template alongside `<router-outlet>`.

**Command Registration Model**

- `Command` interface: `id` (string), `label` (string), `category` ('navigation' | 'action'), `icon?` (string), `shortcutHint?` (string), `keywords` (string[]), `execute` (() => vo

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/command-palette.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/command-palette.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/command-registry.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/command-registry.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/command.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/commands.initializer.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/fuzzy-search.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/fuzzy-search.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/recent-commands.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/command-palette/recent-commands.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/pages/dashboard/dashboard.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/pages/help/help.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/pages/profile/profile.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/pages/settings/settings.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/analytics.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/theme.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/theme.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
Pipeline failed with 0 unresolved issue(s) after 2 review loop(s).

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Add a searchable command palette (Cmd+K / Ctrl+K) that lets users quickly navigate to any page (add a few example pages), search for features, and run common actions like toggle dark mode or open sett -->
<!-- bmad:team_id=SAM1 -->