### PR TITLE
feat(SAM1): Add a notification center - a bell icon in the header that s [SAM1-210]

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,10 +2,15 @@ import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { NotificationDataSource } from './notifications/services/notification-data-source';
+import { StaticNotificationDataSource } from './notifications/services/static-notification-data-source';
+import { AnalyticsService, ConsoleAnalyticsService } from './notifications/services/analytics.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    { provide: NotificationDataSource, useClass: StaticNotificationDataSource },
+    { provide: AnalyticsService, useClass: ConsoleAnalyticsService },
   ]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -182,6 +182,11 @@
   }
 </style>
 
+<header class="app-header">
+  <span class="app-header-title">my-test-app</span>
+  <app-notification-bell />
+</header>
+
 <main class="main">
   <div class="content">
     <div class="left-side">

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import { App } from './app';
+import { NotificationDataSource } from './notifications/services/notification-data-source';
+import { StaticNotificationDataSource } from './notifications/services/static-notification-data-source';
+import { AnalyticsService, ConsoleAnalyticsService } from './notifications/services/analytics.service';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [
+        { provide: NotificationDataSource, useClass: StaticNotificationDataSource },
+        { provide: AnalyticsService, useClass: ConsoleAnalyticsService },
+      ],
     }).compileComponents();
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { NotificationBellComponent } from './notifications/components/notification-bell/notification-bell.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, NotificationBellComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/notifications/components/notification-bell/notification-bell.component.ts
+++ b/src/app/notifications/components/notification-bell/notification-bell.component.ts
@@ -1,0 +1,194 @@
+import {
+  Component,
+  signal,
+  inject,
+  ElementRef,
+  ViewChild,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { NotificationStateService } from '../../services/notification-state.service';
+import { AnalyticsService } from '../../services/analytics.service';
+import { ANALYTICS_EVENTS } from '../../models/notification.model';
+import { NotificationDropdownComponent } from '../notification-dropdown/notification-dropdown.component';
+
+@Component({
+  selector: 'app-notification-bell',
+  standalone: true,
+  imports: [NotificationDropdownComponent],
+  template: `
+    <div class="notification-bell-container">
+      <button
+        #bellButton
+        class="bell-button"
+        (click)="toggleDropdown($event)"
+        [attr.aria-label]="state.unreadCount() > 0
+          ? 'Notifications, ' + state.unreadCount() + ' unread'
+          : 'Notifications'"
+        aria-haspopup="true"
+        [attr.aria-expanded]="isOpen()"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+          <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+        </svg>
+        @if (state.unreadCount() > 0) {
+          <span class="badge" aria-hidden="true">
+            {{ state.unreadCount() > 99 ? '99+' : state.unreadCount() }}
+          </span>
+        }
+      </button>
+      @if (isOpen()) {
+        <app-notification-dropdown (close)="closeDropdown()" />
+      }
+    </div>
+  `,
+  styles: `
+    .notification-bell-container {
+      position: relative;
+      display: inline-flex;
+    }
+
+    .bell-button {
+      position: relative;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 8px;
+      border-radius: 8px;
+      color: #374151;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
+      transition: background-color 0.15s ease;
+    }
+
+    .bell-button:hover {
+      background-color: #f3f4f6;
+    }
+
+    .bell-button:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: 2px;
+    }
+
+    .badge {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      background-color: #dc2626;
+      color: #ffffff;
+      font-size: 11px;
+      font-weight: 600;
+      line-height: 1;
+      padding: 2px 5px;
+      border-radius: 10px;
+      min-width: 18px;
+      max-width: 36px;
+      text-align: center;
+      pointer-events: none;
+    }
+  `,
+})
+export class NotificationBellComponent implements OnInit, OnDestroy {
+  @ViewChild('bellButton') bellButton!: ElementRef<HTMLButtonElement>;
+
+  readonly state = inject(NotificationStateService);
+  private readonly analytics = inject(AnalyticsService);
+  private readonly elementRef = inject(ElementRef);
+
+  isOpen = signal(false);
+
+  private outsideClickListener: ((e: MouseEvent) => void) | null = null;
+  private escapeListener: ((e: KeyboardEvent) => void) | null = null;
+  private mediaQuery: MediaQueryList | null = null;
+  private mediaQueryListener: (() => void) | null = null;
+
+  ngOnInit(): void {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      this.mediaQuery = window.matchMedia('(max-width: 480px)');
+      this.mediaQueryListener = () => {
+        if (this.isOpen()) {
+          this.closeDropdown();
+        }
+      };
+      this.mediaQuery.addEventListener('change', this.mediaQueryListener);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.removeGlobalListeners();
+    if (this.mediaQuery && this.mediaQueryListener) {
+      this.mediaQuery.removeEventListener('change', this.mediaQueryListener);
+    }
+  }
+
+  toggleDropdown(event: MouseEvent): void {
+    event.stopPropagation();
+    if (this.isOpen()) {
+      this.closeDropdown();
+    } else {
+      this.openDropdown();
+    }
+  }
+
+  closeDropdown(): void {
+    this.isOpen.set(false);
+    this.removeGlobalListeners();
+    this.analytics.track(ANALYTICS_EVENTS.NOTIFICATION_CENTER_CLOSED, {
+      timestamp: new Date().toISOString(),
+    });
+    // Return focus to bell button
+    setTimeout(() => this.bellButton?.nativeElement?.focus());
+  }
+
+  private openDropdown(): void {
+    this.isOpen.set(true);
+    this.addGlobalListeners();
+    this.analytics.track(ANALYTICS_EVENTS.NOTIFICATION_CENTER_OPENED, {
+      timestamp: new Date().toISOString(),
+      unread_count: this.state.unreadCount(),
+    });
+  }
+
+  private addGlobalListeners(): void {
+    this.outsideClickListener = (e: MouseEvent) => {
+      if (!this.elementRef.nativeElement.contains(e.target as Node)) {
+        this.closeDropdown();
+      }
+    };
+    this.escapeListener = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        this.closeDropdown();
+      }
+    };
+    // Delay to avoid the current click event triggering the outside click handler
+    setTimeout(() => {
+      document.addEventListener('click', this.outsideClickListener!);
+      document.addEventListener('keydown', this.escapeListener!);
+    });
+  }
+
+  private removeGlobalListeners(): void {
+    if (this.outsideClickListener) {
+      document.removeEventListener('click', this.outsideClickListener);
+      this.outsideClickListener = null;
+    }
+    if (this.escapeListener) {
+      document.removeEventListener('keydown', this.escapeListener);
+      this.escapeListener = null;
+    }
+  }
+}

--- a/src/app/notifications/components/notification-dropdown/notification-dropdown.component.ts
+++ b/src/app/notifications/components/notification-dropdown/notification-dropdown.component.ts
@@ -1,0 +1,354 @@
+import { Component, output, inject, ElementRef, OnInit, OnDestroy, signal } from '@angular/core';
+import { NotificationStateService } from '../../services/notification-state.service';
+import { AnalyticsService } from '../../services/analytics.service';
+import { ANALYTICS_EVENTS } from '../../models/notification.model';
+import { NotificationItemComponent } from '../notification-item/notification-item.component';
+import { NotificationEmptyStateComponent } from '../notification-empty-state/notification-empty-state.component';
+
+@Component({
+  selector: 'app-notification-dropdown',
+  standalone: true,
+  imports: [NotificationItemComponent, NotificationEmptyStateComponent],
+  template: `
+    <div
+      class="dropdown-panel"
+      role="dialog"
+      aria-label="Notification center"
+      (keydown.escape)="onEscape($event)"
+    >
+      <div class="dropdown-header">
+        <h2 class="dropdown-title">Notifications</h2>
+        <div class="header-actions">
+          @if (state.notifications().length > 0) {
+            <button
+              class="mark-all-btn"
+              (click)="onMarkAllRead()"
+              [disabled]="state.unreadCount() === 0"
+              [attr.aria-disabled]="state.unreadCount() === 0"
+            >
+              Mark all as read
+            </button>
+          }
+          <button
+            class="close-btn mobile-only"
+            (click)="close.emit()"
+            aria-label="Close notifications"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div class="dropdown-body">
+        @if (state.notifications().length === 0) {
+          <app-notification-empty-state />
+        } @else {
+          <div class="notification-list">
+            @if (state.groupedNotifications().today.length > 0) {
+              <div class="group-header">Today</div>
+              @for (n of state.groupedNotifications().today; track n.id) {
+                <app-notification-item
+                  [notification]="n"
+                  [isRead]="state.isRead(n.id)"
+                  (markRead)="onMarkRead($event)"
+                />
+              }
+            }
+            @if (state.groupedNotifications().yesterday.length > 0) {
+              <div class="group-header">Yesterday</div>
+              @for (n of state.groupedNotifications().yesterday; track n.id) {
+                <app-notification-item
+                  [notification]="n"
+                  [isRead]="state.isRead(n.id)"
+                  (markRead)="onMarkRead($event)"
+                />
+              }
+            }
+            @if (state.groupedNotifications().older.length > 0) {
+              <div class="group-header">Older</div>
+              @for (n of state.groupedNotifications().older; track n.id) {
+                <app-notification-item
+                  [notification]="n"
+                  [isRead]="state.isRead(n.id)"
+                  (markRead)="onMarkRead($event)"
+                />
+              }
+            }
+          </div>
+        }
+      </div>
+      <div class="scroll-fade" aria-hidden="true"></div>
+      <div
+        class="sr-announcement"
+        aria-live="polite"
+        role="status"
+      >
+        {{ announcement() }}
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+
+    .dropdown-panel {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      width: 360px;
+      max-width: 100vw;
+      max-height: 480px;
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1), 0 4px 10px rgba(0, 0, 0, 0.05);
+      display: flex;
+      flex-direction: column;
+      z-index: 1000;
+      animation: dropdownOpen 180ms ease-out;
+      overflow: hidden;
+    }
+
+    @keyframes dropdownOpen {
+      from {
+        opacity: 0;
+        transform: scale(0.95) translateY(-4px);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+      }
+    }
+
+    .dropdown-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px;
+      border-bottom: 1px solid #e5e7eb;
+      flex-shrink: 0;
+    }
+
+    .dropdown-title {
+      font-size: 16px;
+      font-weight: 600;
+      color: #111827;
+      margin: 0;
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .mark-all-btn {
+      background: none;
+      border: none;
+      color: #2563eb;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      padding: 8px 12px;
+      border-radius: 6px;
+      min-width: 44px;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color 0.15s ease;
+    }
+
+    .mark-all-btn:hover:not(:disabled) {
+      background-color: #eff6ff;
+    }
+
+    .mark-all-btn:disabled {
+      color: #9ca3af;
+      cursor: default;
+    }
+
+    .mark-all-btn:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: 2px;
+    }
+
+    .close-btn {
+      background: none;
+      border: none;
+      color: #6b7280;
+      cursor: pointer;
+      padding: 8px;
+      border-radius: 6px;
+      min-width: 44px;
+      min-height: 44px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .close-btn:hover {
+      background-color: #f3f4f6;
+    }
+
+    .close-btn:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: 2px;
+    }
+
+    .dropdown-body {
+      flex: 1;
+      overflow-y: auto;
+      position: relative;
+    }
+
+    .notification-list {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .group-header {
+      position: sticky;
+      top: 0;
+      background: #f9fafb;
+      padding: 8px 16px;
+      font-size: 12px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border-bottom: 1px solid #e5e7eb;
+      z-index: 1;
+    }
+
+    .scroll-fade {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 24px;
+      background: linear-gradient(transparent, rgba(255, 255, 255, 0.8));
+      pointer-events: none;
+    }
+
+    .sr-announcement {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (max-width: 480px) {
+      .dropdown-panel {
+        position: fixed;
+        top: auto;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        max-height: 70vh;
+        border-radius: 12px 12px 0 0;
+      }
+
+      .close-btn.mobile-only {
+        display: flex;
+      }
+    }
+  `,
+})
+export class NotificationDropdownComponent implements OnInit, OnDestroy {
+  close = output<void>();
+  readonly state = inject(NotificationStateService);
+  private readonly analytics = inject(AnalyticsService);
+  private readonly elementRef = inject(ElementRef);
+
+  announcement = signal('');
+
+  private focusTrapListener: ((e: KeyboardEvent) => void) | null = null;
+
+  ngOnInit(): void {
+    // Focus the first focusable element in the dropdown
+    setTimeout(() => {
+      const focusable = this.getFocusableElements();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    });
+
+    // Set up focus trap
+    this.focusTrapListener = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = this.getFocusableElements();
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    this.elementRef.nativeElement.addEventListener('keydown', this.focusTrapListener);
+
+    // Track empty state
+    if (this.state.notifications().length === 0) {
+      this.analytics.track(ANALYTICS_EVENTS.NOTIFICATION_EMPTY_STATE_SHOWN, {
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.focusTrapListener) {
+      this.elementRef.nativeElement.removeEventListener('keydown', this.focusTrapListener);
+    }
+  }
+
+  onEscape(event: Event): void {
+    event.stopPropagation();
+    this.close.emit();
+  }
+
+  onMarkRead(id: string): void {
+    const notification = this.state.notifications().find((n) => n.id === id);
+    this.state.markAsRead(id);
+    this.analytics.track(ANALYTICS_EVENTS.NOTIFICATION_MARKED_READ, {
+      notification_id: id,
+      notification_type: notification?.type,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  onMarkAllRead(): void {
+    const count = this.state.unreadCount();
+    this.state.markAllAsRead();
+    this.announcement.set('All notifications marked as read');
+    this.analytics.track(ANALYTICS_EVENTS.NOTIFICATIONS_ALL_MARKED_READ, {
+      count_marked: count,
+      timestamp: new Date().toISOString(),
+    });
+    // Clear announcement after screen reader has time to read it
+    setTimeout(() => this.announcement.set(''), 3000);
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const el = this.elementRef.nativeElement as HTMLElement;
+    return Array.from(
+      el.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    );
+  }
+}

--- a/src/app/notifications/components/notification-empty-state/notification-empty-state.component.spec.ts
+++ b/src/app/notifications/components/notification-empty-state/notification-empty-state.component.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { NotificationEmptyStateComponent } from './notification-empty-state.component';
+
+describe('NotificationEmptyStateComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotificationEmptyStateComponent],
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(NotificationEmptyStateComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should display "No notifications yet" text', () => {
+    const fixture = TestBed.createComponent(NotificationEmptyStateComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('No notifications yet');
+  });
+
+  it('should render an SVG illustration', () => {
+    const fixture = TestBed.createComponent(NotificationEmptyStateComponent);
+    fixture.detectChanges();
+    const svg = (fixture.nativeElement as HTMLElement).querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/src/app/notifications/components/notification-empty-state/notification-empty-state.component.ts
+++ b/src/app/notifications/components/notification-empty-state/notification-empty-state.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-notification-empty-state',
+  standalone: true,
+  template: `
+    <div class="empty-state">
+      <svg
+        width="64"
+        height="64"
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M32 8C24.268 8 18 14.268 18 22v10.34L14.34 38H12v4h40v-4h-2.34L46 32.34V22c0-7.732-6.268-14-14-14z"
+          fill="#d1d5db"
+        />
+        <path d="M26 46a6 6 0 0 0 12 0H26z" fill="#d1d5db" />
+        <path
+          d="M44 26l-8.5 8.5-5.5-5.5-8 8"
+          stroke="#9ca3af"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+        <circle cx="44" cy="26" r="3" fill="#9ca3af" />
+      </svg>
+      <p class="empty-text">No notifications yet</p>
+    </div>
+  `,
+  styles: `
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 24px;
+      gap: 16px;
+    }
+
+    .empty-text {
+      font-size: 14px;
+      color: #6b7280;
+      margin: 0;
+      font-weight: 500;
+    }
+  `,
+})
+export class NotificationEmptyStateComponent {}

--- a/src/app/notifications/components/notification-item/notification-item.component.spec.ts
+++ b/src/app/notifications/components/notification-item/notification-item.component.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { NotificationItemComponent } from './notification-item.component';
+import { AppNotification } from '../../models/notification.model';
+
+const MOCK: AppNotification = {
+  id: 'n1',
+  type: 'info',
+  title: 'Test Title',
+  description: 'Test description text',
+  timestamp: new Date(Date.now() - 5 * 60000).toISOString(),
+};
+
+@Component({
+  standalone: true,
+  imports: [NotificationItemComponent],
+  template: `<app-notification-item [notification]="notification" [isRead]="isRead" (markRead)="onMarkRead($event)" />`,
+})
+class TestHost {
+  notification = MOCK;
+  isRead = false;
+  onMarkRead = vi.fn();
+}
+
+describe('NotificationItemComponent', () => {
+  let fixture: ComponentFixture<TestHost>;
+  let host: TestHost;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHost],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestHost);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should display notification title', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.title')?.textContent).toContain('Test Title');
+  });
+
+  it('should display description', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.description')?.textContent).toContain('Test description text');
+  });
+
+  it('should display relative timestamp', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.timestamp')?.textContent).toContain('5m ago');
+  });
+
+  it('should show unread dot when not read', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.unread-dot')).toBeTruthy();
+  });
+
+  it('should not show unread dot when read', async () => {
+    host.isRead = true;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.unread-dot')).toBeFalsy();
+  });
+
+  it('should have read class when read', async () => {
+    host.isRead = true;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const item = (fixture.nativeElement as HTMLElement).querySelector('.notification-item');
+    expect(item?.classList.contains('read')).toBe(true);
+  });
+
+  it('should emit markRead on click when unread', () => {
+    const item = (fixture.nativeElement as HTMLElement).querySelector('.notification-item') as HTMLElement;
+    item.click();
+    expect(host.onMarkRead).toHaveBeenCalledWith('n1');
+  });
+
+  it('should NOT emit markRead on click when already read', async () => {
+    host.isRead = true;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const item = (fixture.nativeElement as HTMLElement).querySelector('.notification-item') as HTMLElement;
+    item.click();
+    expect(host.onMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('should have correct aria-label', () => {
+    const item = (fixture.nativeElement as HTMLElement).querySelector('.notification-item');
+    expect(item?.getAttribute('aria-label')).toContain('Test Title');
+    expect(item?.getAttribute('aria-label')).toContain('Test description text');
+  });
+
+  it('should have role="button" and tabindex', () => {
+    const item = (fixture.nativeElement as HTMLElement).querySelector('.notification-item');
+    expect(item?.getAttribute('role')).toBe('button');
+    expect(item?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should render type icon', () => {
+    const icon = (fixture.nativeElement as HTMLElement).querySelector('.icon-info');
+    expect(icon).toBeTruthy();
+    expect(icon?.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/src/app/notifications/components/notification-item/notification-item.component.ts
+++ b/src/app/notifications/components/notification-item/notification-item.component.ts
@@ -1,0 +1,169 @@
+import { Component, input, output } from '@angular/core';
+import { AppNotification } from '../../models/notification.model';
+import { RelativeTimePipe } from '../../pipes/relative-time.pipe';
+
+@Component({
+  selector: 'app-notification-item',
+  standalone: true,
+  imports: [RelativeTimePipe],
+  template: `
+    <div
+      class="notification-item"
+      [class.read]="isRead()"
+      (click)="onItemClick()"
+      (keydown.enter)="onItemClick()"
+      (keydown.space)="onItemClick(); $event.preventDefault()"
+      tabindex="0"
+      role="button"
+      [attr.aria-label]="notification().title + '. ' + notification().description"
+    >
+      <div class="icon-container" [class]="'icon-' + notification().type" aria-hidden="true">
+        @switch (notification().type) {
+          @case ('info') {
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a8 8 0 100 16 8 8 0 000-16zm1 11H9v-4h2v4zm0-6H9V5h2v2z"/></svg>
+          }
+          @case ('success') {
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a8 8 0 100 16 8 8 0 000-16zm-1.5 11.5l-3-3 1.41-1.41L8.5 10.67l4.59-4.58L14.5 7.5l-6 6z"/></svg>
+          }
+          @case ('warning') {
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2L1 18h18L10 2zm1 13H9v-2h2v2zm0-4H9V7h2v4z"/></svg>
+          }
+          @case ('error') {
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a8 8 0 100 16 8 8 0 000-16zm1 11H9v-2h2v2zm0-4H9V5h2v4z"/></svg>
+          }
+        }
+      </div>
+      <div class="content">
+        <div class="title-row">
+          <span class="title">{{ notification().title }}</span>
+          <span class="timestamp">{{ notification().timestamp | relativeTime }}</span>
+        </div>
+        <p class="description">{{ notification().description }}</p>
+      </div>
+      @if (!isRead()) {
+        <div class="unread-dot" aria-hidden="true"></div>
+      }
+    </div>
+  `,
+  styles: `
+    .notification-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 12px 16px;
+      cursor: default;
+      transition: background-color 0.15s ease;
+      position: relative;
+      border-left: 3px solid transparent;
+    }
+
+    .notification-item:not(.read) {
+      border-left-color: #3b82f6;
+      background-color: #eff6ff;
+    }
+
+    .notification-item:hover {
+      background-color: #f3f4f6;
+    }
+
+    .notification-item:not(.read):hover {
+      background-color: #dbeafe;
+    }
+
+    .notification-item:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: -2px;
+    }
+
+    .notification-item.read {
+      border-left-color: transparent;
+    }
+
+    .icon-container {
+      flex-shrink: 0;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .icon-info { background-color: #dbeafe; color: #2563eb; }
+    .icon-success { background-color: #dcfce7; color: #16a34a; }
+    .icon-warning { background-color: #fef3c7; color: #d97706; }
+    .icon-error { background-color: #fee2e2; color: #dc2626; }
+
+    .content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .title-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 8px;
+    }
+
+    .title {
+      font-size: 14px;
+      font-weight: 600;
+      color: #111827;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .read .title {
+      font-weight: 400;
+      color: #4b5563;
+    }
+
+    .timestamp {
+      font-size: 12px;
+      color: #6b7280;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .description {
+      font-size: 13px;
+      color: #374151;
+      margin: 4px 0 0;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      line-height: 1.4;
+    }
+
+    .read .description {
+      color: #6b7280;
+    }
+
+    .unread-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: #3b82f6;
+      flex-shrink: 0;
+      margin-top: 6px;
+    }
+  `,
+})
+export class NotificationItemComponent {
+  notification = input.required<AppNotification>();
+  isRead = input.required<boolean>();
+  markRead = output<string>();
+
+  onItemClick(): void {
+    if (!this.isRead()) {
+      this.markRead.emit(this.notification().id);
+    }
+  }
+}

--- a/src/app/notifications/data/seed-notifications.ts
+++ b/src/app/notifications/data/seed-notifications.ts
@@ -1,0 +1,100 @@
+import { AppNotification } from '../models/notification.model';
+
+const now = Date.now();
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+function getYesterdayAt(hoursFromMidnight: number): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = new Date(today.getTime() - DAY + hoursFromMidnight * HOUR);
+  return yesterday.toISOString();
+}
+
+export const SEED_NOTIFICATIONS: readonly AppNotification[] = [
+  {
+    id: 'n1',
+    type: 'success',
+    title: 'Deployment completed',
+    description: 'Your application was successfully deployed to production environment v2.4.1.',
+    timestamp: new Date(now - 5 * MINUTE).toISOString(),
+  },
+  {
+    id: 'n2',
+    type: 'info',
+    title: 'New team member joined',
+    description: 'Sarah Chen has joined the Frontend team. Say hello and help them get started!',
+    timestamp: new Date(now - 32 * MINUTE).toISOString(),
+  },
+  {
+    id: 'n3',
+    type: 'warning',
+    title: 'API rate limit approaching',
+    description: 'Your application has used 85% of the daily API quota. Consider optimizing request frequency to avoid service interruption.',
+    timestamp: new Date(now - 2 * HOUR).toISOString(),
+  },
+  {
+    id: 'n4',
+    type: 'error',
+    title: 'Build pipeline failed',
+    description: 'The CI/CD pipeline for branch feature/auth-redesign failed at the lint stage. Check the logs for details.',
+    timestamp: new Date(now - 4 * HOUR).toISOString(),
+  },
+  {
+    id: 'n5',
+    type: 'info',
+    title: 'Scheduled maintenance window',
+    description: 'Database maintenance is scheduled for Saturday 2:00 AM - 4:00 AM UTC. Expect brief downtime.',
+    timestamp: new Date(now - 6 * HOUR).toISOString(),
+  },
+  {
+    id: 'n6',
+    type: 'success',
+    title: 'Performance report ready',
+    description: 'Your weekly performance report has been generated. Core Web Vitals improved by 12%.',
+    timestamp: getYesterdayAt(14),
+  },
+  {
+    id: 'n7',
+    type: 'warning',
+    title: 'Disk usage high',
+    description: 'Server disk usage is at 92%. Consider cleaning up old logs and temporary files to prevent issues.',
+    timestamp: getYesterdayAt(10),
+  },
+  {
+    id: 'n8',
+    type: 'info',
+    title: 'New comment on PR #247',
+    description: 'Alex Rivera commented: "Looks good overall, but can we add unit tests for the edge case with empty arrays?"',
+    timestamp: getYesterdayAt(8),
+  },
+  {
+    id: 'n9',
+    type: 'error',
+    title: 'SSL certificate expiring soon',
+    description: 'The SSL certificate for api.example.com expires in 7 days. Renew it to avoid service disruption.',
+    timestamp: new Date(now - 3 * DAY).toISOString(),
+  },
+  {
+    id: 'n10',
+    type: 'success',
+    title: 'Milestone achieved',
+    description: 'Congratulations! Your project reached 1,000 active users this week. ThisIsAVeryLongUnbrokenWordToTestOverflowHandlingInTheUI.',
+    timestamp: new Date(now - 4 * DAY).toISOString(),
+  },
+  {
+    id: 'n11',
+    type: 'info',
+    title: 'Security patch available',
+    description: 'A critical security update is available for dependency lodash@4.17.20. Update recommended.',
+    timestamp: new Date(now - 6 * DAY).toISOString(),
+  },
+  {
+    id: 'n12',
+    type: 'warning',
+    title: 'Unused feature flags detected',
+    description: 'Three feature flags have not been evaluated in over 30 days. Consider removing stale flags to reduce complexity.',
+    timestamp: new Date(now - 10 * DAY).toISOString(),
+  },
+];

--- a/src/app/notifications/models/notification.model.ts
+++ b/src/app/notifications/models/notification.model.ts
@@ -1,0 +1,27 @@
+export type NotificationType = 'info' | 'warning' | 'success' | 'error';
+
+export interface AppNotification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  description: string;
+  timestamp: string; // ISO 8601
+}
+
+export interface NotificationReadMap {
+  [notificationId: string]: string; // value is ISO timestamp of when marked read
+}
+
+export interface GroupedNotifications {
+  today: AppNotification[];
+  yesterday: AppNotification[];
+  older: AppNotification[];
+}
+
+export const ANALYTICS_EVENTS = {
+  NOTIFICATION_CENTER_OPENED: 'notification_center_opened',
+  NOTIFICATION_CENTER_CLOSED: 'notification_center_closed',
+  NOTIFICATION_MARKED_READ: 'notification_marked_read',
+  NOTIFICATIONS_ALL_MARKED_READ: 'notifications_all_marked_read',
+  NOTIFICATION_EMPTY_STATE_SHOWN: 'notification_empty_state_shown',
+} as const;

--- a/src/app/notifications/pipes/relative-time.pipe.spec.ts
+++ b/src/app/notifications/pipes/relative-time.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { RelativeTimePipe } from './relative-time.pipe';
+
+describe('RelativeTimePipe', () => {
+  const pipe = new RelativeTimePipe();
+
+  it('should transform an ISO string to relative time', () => {
+    const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(pipe.transform(recent)).toBe('5m ago');
+  });
+
+  it('should return "just now" for very recent timestamps', () => {
+    expect(pipe.transform(new Date().toISOString())).toBe('just now');
+  });
+
+  it('should accept optional refreshTick argument without error', () => {
+    const iso = new Date(Date.now() - 120000).toISOString();
+    expect(pipe.transform(iso, 1)).toBe('2m ago');
+  });
+});

--- a/src/app/notifications/pipes/relative-time.pipe.ts
+++ b/src/app/notifications/pipes/relative-time.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatRelativeTime } from '../utils/date-utils';
+
+/**
+ * Transforms an ISO 8601 timestamp to a relative time string.
+ * Note: This is a pure pipe and won't re-evaluate while the dropdown stays open.
+ * A future enhancement can pass a `refreshTick` argument to force re-evaluation.
+ */
+@Pipe({
+  name: 'relativeTime',
+  standalone: true,
+  pure: true,
+})
+export class RelativeTimePipe implements PipeTransform {
+  transform(isoString: string, _refreshTick?: number): string {
+    return formatRelativeTime(isoString);
+  }
+}

--- a/src/app/notifications/services/analytics.service.ts
+++ b/src/app/notifications/services/analytics.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+export abstract class AnalyticsService {
+  abstract track(eventName: string, meta: Record<string, unknown>): void;
+}
+
+@Injectable()
+export class ConsoleAnalyticsService extends AnalyticsService {
+  track(eventName: string, meta: Record<string, unknown>): void {
+    console.debug('[Analytics]', eventName, meta);
+  }
+}

--- a/src/app/notifications/services/notification-data-source.ts
+++ b/src/app/notifications/services/notification-data-source.ts
@@ -1,0 +1,6 @@
+import { Observable } from 'rxjs';
+import { AppNotification } from '../models/notification.model';
+
+export abstract class NotificationDataSource {
+  abstract getNotifications(): Observable<AppNotification[]>;
+}

--- a/src/app/notifications/services/notification-state.service.spec.ts
+++ b/src/app/notifications/services/notification-state.service.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { NotificationStateService } from './notification-state.service';
+import { NotificationDataSource } from './notification-data-source';
+import { StorageAdapter } from './storage-adapter';
+import { AppNotification } from '../models/notification.model';
+
+const STORAGE_KEY = 'notification-center-read-status';
+
+const MOCK_NOTIFICATIONS: AppNotification[] = [
+  { id: 'n1', type: 'info', title: 'A', description: 'Desc A', timestamp: new Date().toISOString() },
+  { id: 'n2', type: 'warning', title: 'B', description: 'Desc B', timestamp: new Date(Date.now() - 86400000).toISOString() },
+  { id: 'n3', type: 'error', title: 'C', description: 'Desc C', timestamp: new Date(Date.now() - 3 * 86400000).toISOString() },
+];
+
+class MockDataSource extends NotificationDataSource {
+  getNotifications() { return of([...MOCK_NOTIFICATIONS]); }
+}
+
+class InMemoryStorage {
+  private store: Record<string, string> = {};
+  getItem(key: string) { return this.store[key] ?? null; }
+  setItem(key: string, value: string) { this.store[key] = value; }
+  removeItem(key: string) { delete this.store[key]; }
+}
+
+describe('NotificationStateService', () => {
+  let service: NotificationStateService;
+  let storage: InMemoryStorage;
+
+  beforeEach(() => {
+    storage = new InMemoryStorage();
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: storage },
+      ],
+    });
+    service = TestBed.inject(NotificationStateService);
+  });
+
+  it('should load notifications from data source', () => {
+    expect(service.notifications().length).toBe(3);
+  });
+
+  it('should start with all notifications unread', () => {
+    expect(service.unreadCount()).toBe(3);
+  });
+
+  it('should mark a single notification as read', () => {
+    service.markAsRead('n1');
+    expect(service.isRead('n1')).toBe(true);
+    expect(service.unreadCount()).toBe(2);
+  });
+
+  it('should persist read status to storage', () => {
+    service.markAsRead('n1');
+    const stored = JSON.parse(storage.getItem(STORAGE_KEY)!);
+    expect(stored['n1']).toBeTruthy();
+  });
+
+  it('should not re-mark already read notification', () => {
+    service.markAsRead('n1');
+    const ts1 = JSON.parse(storage.getItem(STORAGE_KEY)!)['n1'];
+    service.markAsRead('n1');
+    const ts2 = JSON.parse(storage.getItem(STORAGE_KEY)!)['n1'];
+    expect(ts1).toBe(ts2);
+  });
+
+  it('should mark all as read', () => {
+    service.markAllAsRead();
+    expect(service.unreadCount()).toBe(0);
+    const stored = JSON.parse(storage.getItem(STORAGE_KEY)!);
+    expect(Object.keys(stored).length).toBe(3);
+  });
+
+  it('should not change read map if all already read', () => {
+    service.markAllAsRead();
+    const map1 = storage.getItem(STORAGE_KEY);
+    service.markAllAsRead();
+    const map2 = storage.getItem(STORAGE_KEY);
+    expect(map1).toBe(map2);
+  });
+
+  it('should group notifications correctly', () => {
+    const grouped = service.groupedNotifications();
+    expect(grouped.today.length + grouped.yesterday.length + grouped.older.length).toBe(3);
+  });
+
+  it('should restore read status from storage on init', () => {
+    const readMap = { n1: new Date().toISOString(), n2: new Date().toISOString() };
+    storage.setItem(STORAGE_KEY, JSON.stringify(readMap));
+
+    // Create a new service instance that loads from storage
+    const service2 = TestBed.inject(NotificationStateService);
+    // Since it's providedIn root, same instance. We need a fresh one.
+    // Actually, the singleton was already created. Let's test via a new TestBed.
+    TestBed.resetTestingModule();
+    const store2 = new InMemoryStorage();
+    store2.setItem(STORAGE_KEY, JSON.stringify(readMap));
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: store2 },
+      ],
+    });
+    const fresh = TestBed.inject(NotificationStateService);
+    expect(fresh.isRead('n1')).toBe(true);
+    expect(fresh.isRead('n2')).toBe(true);
+    expect(fresh.unreadCount()).toBe(1);
+  });
+
+  it('should handle corrupted storage data gracefully', () => {
+    TestBed.resetTestingModule();
+    const store2 = new InMemoryStorage();
+    store2.setItem(STORAGE_KEY, 'not-json!!!');
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: store2 },
+      ],
+    });
+    const fresh = TestBed.inject(NotificationStateService);
+    expect(fresh.unreadCount()).toBe(3);
+  });
+
+  it('should handle array as storage data gracefully', () => {
+    TestBed.resetTestingModule();
+    const store2 = new InMemoryStorage();
+    store2.setItem(STORAGE_KEY, '[1,2,3]');
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: store2 },
+      ],
+    });
+    const fresh = TestBed.inject(NotificationStateService);
+    expect(fresh.unreadCount()).toBe(3);
+  });
+
+  it('should prune entries older than 90 days', () => {
+    TestBed.resetTestingModule();
+    const store2 = new InMemoryStorage();
+    const old = new Date(Date.now() - 91 * 86400000).toISOString();
+    const recent = new Date().toISOString();
+    store2.setItem(STORAGE_KEY, JSON.stringify({ n1: old, n2: recent }));
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: store2 },
+      ],
+    });
+    const fresh = TestBed.inject(NotificationStateService);
+    expect(fresh.isRead('n1')).toBe(false); // pruned
+    expect(fresh.isRead('n2')).toBe(true);  // kept
+  });
+
+  it('should handle storage write failure gracefully (in-memory still works)', () => {
+    const failStore = {
+      getItem: () => null,
+      setItem: () => { throw new Error('quota'); },
+      removeItem: () => {},
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationStateService,
+        { provide: NotificationDataSource, useClass: MockDataSource },
+        { provide: StorageAdapter, useValue: failStore },
+      ],
+    });
+    const fresh = TestBed.inject(NotificationStateService);
+    // markAsRead will call persistReadMap which calls setItem which throws,
+    // but the in-memory signal should still be updated
+    // Actually, looking at the code, the service doesn't try/catch on persist.
+    // The StorageAdapter itself handles the try/catch. Let's verify it doesn't crash.
+    expect(() => fresh.markAsRead('n1')).not.toThrow();
+  });
+});

--- a/src/app/notifications/services/notification-state.service.ts
+++ b/src/app/notifications/services/notification-state.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, signal, computed, inject } from '@angular/core';
+import {
+  AppNotification,
+  NotificationReadMap,
+  GroupedNotifications,
+} from '../models/notification.model';
+import { NotificationDataSource } from './notification-data-source';
+import { StorageAdapter } from './storage-adapter';
+import { groupByDate } from '../utils/date-utils';
+
+const STORAGE_KEY = 'notification-center-read-status';
+const PRUNE_DAYS = 90;
+
+@Injectable({ providedIn: 'root' })
+export class NotificationStateService {
+  private readonly dataSource = inject(NotificationDataSource);
+  private readonly storage = inject(StorageAdapter);
+
+  private readonly _notifications = signal<AppNotification[]>([]);
+  private readonly _readMap = signal<NotificationReadMap>({});
+
+  readonly notifications = this._notifications.asReadonly();
+  readonly readMap = this._readMap.asReadonly();
+
+  readonly unreadCount = computed(() => {
+    const map = this._readMap();
+    return this._notifications().filter((n) => !map[n.id]).length;
+  });
+
+  readonly groupedNotifications = computed<GroupedNotifications>(() => {
+    return groupByDate(this._notifications());
+  });
+
+  constructor() {
+    this.loadReadMap();
+    this.dataSource.getNotifications().subscribe((notifications) => {
+      this._notifications.set(notifications);
+    });
+  }
+
+  isRead(id: string): boolean {
+    return !!this._readMap()[id];
+  }
+
+  markAsRead(id: string): void {
+    const current = this._readMap();
+    if (current[id]) return;
+    const updated = { ...current, [id]: new Date().toISOString() };
+    this._readMap.set(updated);
+    this.persistReadMap(updated);
+  }
+
+  markAllAsRead(): void {
+    const current = this._readMap();
+    const updated = { ...current };
+    const now = new Date().toISOString();
+    let changed = false;
+    for (const n of this._notifications()) {
+      if (!updated[n.id]) {
+        updated[n.id] = now;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this._readMap.set(updated);
+      this.persistReadMap(updated);
+    }
+  }
+
+  private loadReadMap(): void {
+    const raw = this.storage.getItem(STORAGE_KEY);
+    if (!raw) return;
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return;
+      }
+      const pruned = this.pruneOldEntries(parsed as NotificationReadMap);
+      this._readMap.set(pruned);
+      this.persistReadMap(pruned);
+    } catch {
+      // Corrupted data — start fresh
+    }
+  }
+
+  private pruneOldEntries(map: NotificationReadMap): NotificationReadMap {
+    const cutoff = Date.now() - PRUNE_DAYS * 24 * 60 * 60 * 1000;
+    const pruned: NotificationReadMap = {};
+    for (const [id, ts] of Object.entries(map)) {
+      const time = new Date(ts).getTime();
+      if (!isNaN(time) && time >= cutoff) {
+        pruned[id] = ts;
+      }
+    }
+    return pruned;
+  }
+
+  private persistReadMap(map: NotificationReadMap): void {
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(map));
+    } catch {
+      // Storage write failed (quota exceeded, private browsing, etc.)
+      // Degrade gracefully — in-memory state is still valid
+    }
+  }
+}

--- a/src/app/notifications/services/static-notification-data-source.spec.ts
+++ b/src/app/notifications/services/static-notification-data-source.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { StaticNotificationDataSource } from './static-notification-data-source';
+import { firstValueFrom } from 'rxjs';
+
+describe('StaticNotificationDataSource', () => {
+  it('should return seed notifications', async () => {
+    const ds = new StaticNotificationDataSource();
+    const notifications = await firstValueFrom(ds.getNotifications());
+    expect(notifications.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('should return a copy (not the original array)', async () => {
+    const ds = new StaticNotificationDataSource();
+    const a = await firstValueFrom(ds.getNotifications());
+    const b = await firstValueFrom(ds.getNotifications());
+    expect(a).not.toBe(b);
+  });
+
+  it('each notification should have required fields', async () => {
+    const ds = new StaticNotificationDataSource();
+    const notifications = await firstValueFrom(ds.getNotifications());
+    for (const n of notifications) {
+      expect(n.id).toBeTruthy();
+      expect(n.type).toMatch(/^(info|warning|success|error)$/);
+      expect(n.title).toBeTruthy();
+      expect(n.description).toBeTruthy();
+      expect(n.timestamp).toBeTruthy();
+      expect(() => new Date(n.timestamp)).not.toThrow();
+    }
+  });
+});

--- a/src/app/notifications/services/static-notification-data-source.ts
+++ b/src/app/notifications/services/static-notification-data-source.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { AppNotification } from '../models/notification.model';
+import { NotificationDataSource } from './notification-data-source';
+import { SEED_NOTIFICATIONS } from '../data/seed-notifications';
+
+@Injectable()
+export class StaticNotificationDataSource extends NotificationDataSource {
+  getNotifications(): Observable<AppNotification[]> {
+    return of([...SEED_NOTIFICATIONS]);
+  }
+}

--- a/src/app/notifications/services/storage-adapter.spec.ts
+++ b/src/app/notifications/services/storage-adapter.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StorageAdapter } from './storage-adapter';
+
+describe('StorageAdapter', () => {
+  let adapter: StorageAdapter;
+
+  beforeEach(() => {
+    adapter = new StorageAdapter();
+    localStorage.clear();
+  });
+
+  it('should get item from localStorage', () => {
+    localStorage.setItem('key', 'value');
+    expect(adapter.getItem('key')).toBe('value');
+  });
+
+  it('should return null for missing key', () => {
+    expect(adapter.getItem('missing')).toBeNull();
+  });
+
+  it('should set item in localStorage', () => {
+    adapter.setItem('key', 'value');
+    expect(localStorage.getItem('key')).toBe('value');
+  });
+
+  it('should remove item from localStorage', () => {
+    localStorage.setItem('key', 'value');
+    adapter.removeItem('key');
+    expect(localStorage.getItem('key')).toBeNull();
+  });
+
+  it('should return null when getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('denied'); });
+    expect(adapter.getItem('key')).toBeNull();
+    vi.restoreAllMocks();
+  });
+
+  it('should not throw when setItem fails', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota'); });
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => adapter.setItem('key', 'val')).not.toThrow();
+    expect(spy).toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('should not throw when removeItem fails', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => { throw new Error(); });
+    expect(() => adapter.removeItem('key')).not.toThrow();
+    vi.restoreAllMocks();
+  });
+});

--- a/src/app/notifications/services/storage-adapter.ts
+++ b/src/app/notifications/services/storage-adapter.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class StorageAdapter {
+  getItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  setItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch (e) {
+      console.warn('StorageAdapter: failed to write to localStorage', e);
+    }
+  }
+
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // silently degrade
+    }
+  }
+}

--- a/src/app/notifications/utils/date-utils.spec.ts
+++ b/src/app/notifications/utils/date-utils.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isToday, isYesterday, formatRelativeTime, groupByDate, getStartOfDay } from './date-utils';
+import { AppNotification } from '../models/notification.model';
+
+describe('date-utils', () => {
+  describe('getStartOfDay', () => {
+    it('should return midnight of the given date', () => {
+      const d = new Date(2026, 2, 17, 14, 30, 45);
+      const result = getStartOfDay(d);
+      expect(result.getHours()).toBe(0);
+      expect(result.getMinutes()).toBe(0);
+      expect(result.getSeconds()).toBe(0);
+      expect(result.getMilliseconds()).toBe(0);
+      expect(result.getDate()).toBe(17);
+    });
+
+    it('should not mutate the input date', () => {
+      const d = new Date(2026, 2, 17, 14, 30);
+      getStartOfDay(d);
+      expect(d.getHours()).toBe(14);
+    });
+  });
+
+  describe('isToday', () => {
+    it('should return true for a date today', () => {
+      expect(isToday(new Date())).toBe(true);
+    });
+
+    it('should return true for start of today', () => {
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      expect(isToday(start)).toBe(true);
+    });
+
+    it('should return false for yesterday', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(12, 0, 0, 0);
+      expect(isToday(yesterday)).toBe(false);
+    });
+  });
+
+  describe('isYesterday', () => {
+    it('should return true for a date yesterday', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(12, 0, 0, 0);
+      expect(isYesterday(yesterday)).toBe(true);
+    });
+
+    it('should return false for today', () => {
+      expect(isYesterday(new Date())).toBe(false);
+    });
+
+    it('should return false for two days ago', () => {
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      twoDaysAgo.setHours(12, 0, 0, 0);
+      expect(isYesterday(twoDaysAgo)).toBe(false);
+    });
+
+    it('should return true for start of yesterday', () => {
+      const startOfToday = new Date();
+      startOfToday.setHours(0, 0, 0, 0);
+      const startOfYesterday = new Date(startOfToday);
+      startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+      expect(isYesterday(startOfYesterday)).toBe(true);
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    it('should return "just now" for times less than 60 seconds ago', () => {
+      const iso = new Date(Date.now() - 30 * 1000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('just now');
+    });
+
+    it('should return "just now" for future timestamps', () => {
+      const iso = new Date(Date.now() + 60000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('just now');
+    });
+
+    it('should return minutes ago', () => {
+      const iso = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('5m ago');
+    });
+
+    it('should return hours ago', () => {
+      const iso = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('3h ago');
+    });
+
+    it('should return "Yesterday" for 1 day ago', () => {
+      const iso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('Yesterday');
+    });
+
+    it('should return days ago for 2-6 days', () => {
+      const iso = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(iso)).toBe('3d ago');
+    });
+
+    it('should return formatted date for 7+ days', () => {
+      const iso = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+      const result = formatRelativeTime(iso);
+      // Should be a locale date string like "Mar 7"
+      expect(result).toBeTruthy();
+      expect(result).not.toContain('ago');
+    });
+  });
+
+  describe('groupByDate', () => {
+    it('should group notifications into today, yesterday, older', () => {
+      const now = Date.now();
+      const DAY = 24 * 60 * 60 * 1000;
+      const notifications: AppNotification[] = [
+        { id: '1', type: 'info', title: 'T', description: 'D', timestamp: new Date(now - 1000).toISOString() },
+        { id: '2', type: 'info', title: 'T', description: 'D', timestamp: new Date(now - DAY).toISOString() },
+        { id: '3', type: 'info', title: 'T', description: 'D', timestamp: new Date(now - 3 * DAY).toISOString() },
+      ];
+
+      const result = groupByDate(notifications);
+      expect(result.today.length).toBeGreaterThanOrEqual(1);
+      expect(result.older.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should return empty arrays when no notifications', () => {
+      const result = groupByDate([]);
+      expect(result.today).toEqual([]);
+      expect(result.yesterday).toEqual([]);
+      expect(result.older).toEqual([]);
+    });
+  });
+});

--- a/src/app/notifications/utils/date-utils.ts
+++ b/src/app/notifications/utils/date-utils.ts
@@ -1,0 +1,73 @@
+import { AppNotification, GroupedNotifications } from '../models/notification.model';
+
+export function getStartOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function isToday(date: Date): boolean {
+  const now = new Date();
+  const startOfToday = getStartOfDay(now);
+  return date >= startOfToday;
+}
+
+export function isYesterday(date: Date): boolean {
+  const now = new Date();
+  const startOfToday = getStartOfDay(now);
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+  return date >= startOfYesterday && date < startOfToday;
+}
+
+export function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+
+  if (diffMs < 0) {
+    return 'just now';
+  }
+
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) {
+    return 'just now';
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes}m ago`;
+  }
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+  if (diffDays === 1) {
+    return 'Yesterday';
+  }
+  if (diffDays < 7) {
+    return `${diffDays}d ago`;
+  }
+
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function groupByDate(notifications: AppNotification[]): GroupedNotifications {
+  const today: AppNotification[] = [];
+  const yesterday: AppNotification[] = [];
+  const older: AppNotification[] = [];
+
+  for (const n of notifications) {
+    const date = new Date(n.timestamp);
+    if (isToday(date)) {
+      today.push(n);
+    } else if (isYesterday(date)) {
+      yesterday.push(n);
+    } else {
+      older.push(n);
+    }
+  }
+
+  return { today, yesterday, older };
+}


### PR DESCRIPTION
## Story
**SAM1-210**: **Hypothesis**

## Acceptance Criteria
- Given the user is on any authenticated page, when the header renders, then a bell icon button is visible with correct ARIA attributes (aria-label, aria-haspopup, aria-expanded); when N > 0 unread notifications exist, a badge shows N (or '99+' if N > 99); when N = 0, the badge is hidden.
- Given the bell icon is visible, when the user clicks it, then the dropdown opens with focus moving into the panel and aria-expanded set to true; when the user clicks the bell again, clicks outside, or presses Escape, the dropdown closes and focus returns to the bell button.
- Given the dropdown is open and notifications exist, when they render, then they are grouped under sticky 'Today', 'Yesterday', and 'Older' headers based on calendar-day boundaries in the user's local timezone, and empty groups are omitted.
- Given a notification renders in the dropdown, then it displays a type icon, bold single-line-truncated title, two-line-clamped description (with overflow-wrap for unbroken strings), and a relative timestamp computed from an absolute ISO 8601 date field.
- Given an unread notification, when the user clicks it, then it transitions to read style, the badge decrements, and localStorage is updated immediately; given unread notifications exist, when 'Mark all as read' is clicked, then all transition to read state, the badge disappears, localStorage is batch-updated, and an aria-live region announces confirmation.
- Given no notifications exist, when the dropdown opens, then an empty-state inline SVG illustration and 'No notifications yet' message are displayed and 'Mark all as read' is hidden; given notifications exist but all are read, then the full list renders in muted style and 'Mark all as read' is disabled — these are two distinct UI states.
- Given the user marks notifications as read and reloads the page, then read status is preserved from localStorage; given localStorage is unavailable (private browsing, quota exceeded) or stored data is corrupted/malformed, then the component degrades gracefully to in-memory-only state with all notifications treated as unread and no errors thrown.
- Given a viewport width below 480px, when the dropdown renders, then it displays full-width with a visible close (X) button and max-height of 70vh with internal scroll; given a keyboard-only user, then all interactive elements are reachable via Tab, focus is trapped inside the open dropdown, and all text meets WCAG AA 4.5:1 contrast ratio.

## Implementation Details
### Architecture


# Technical Architecture Review: Notification Center

## Data Model Changes

No backend or database changes are required for this iteration. All state is client-side.

**Notification interface** — define in `src/app/notifications/models/notification.model.ts`:

```typescript
export type NotificationType = 'info' | 'warning' | 'success' | 'error';

export interface AppNotification {
  id: string;
  type: NotificationType;
  title: string;
  description: string;
  timestamp: string; // ISO 8601
}

export interface NotificationReadMap {
  [notificationId: string]: string; // value is ISO timest

### Developer Notes
**Feature Structure**
All code lives under `src/app/notifications/` as standalone components — no NgModule. File tree: `models/`, `data/`, `utils/`, `services/`, `pipes/`, `components/` (notification-bell, notification-dropdown, notification-item, notification-empty-state).

**Data Model**
- Define `AppNotification` interface with `id: string`, `type: NotificationType` (`'info' | 'warning' | 'success' | 'error'`), `title: string`, `description: string`, `timestamp: string` (ISO 8601) in `models/notification.model.ts`
- Define `NotificationReadMap` as `{ [notificationId: string]: string }` (val

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-bell/notification-bell.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-dropdown/notification-dropdown.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-empty-state/notification-empty-state.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-empty-state/notification-empty-state.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-item/notification-item.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/components/notification-item/notification-item.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/data/seed-notifications.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/models/notification.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/pipes/relative-time.pipe.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/pipes/relative-time.pipe.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/notification-data-source.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/notification-state.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/notification-state.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/static-notification-data-source.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/static-notification-data-source.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/storage-adapter.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/services/storage-adapter.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/utils/date-utils.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/notifications/utils/date-utils.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Add a notification center - a bell icon in the header that shows a dropdown with recent notifications grouped by today/yesterday/older. Each notification has an icon, title, description, and timestamp -->
<!-- bmad:team_id=SAM1 -->