### PR TITLE
feat(SAM1): As a new user, I want to re-enter my password as a confirmat [SAM1-61]

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { errorInterceptor } from './interceptors/error.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient(withInterceptors([errorInterceptor]))
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { SignupStep1Component } from './features/signup/signup-step1.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'signup/step1', component: SignupStep1Component },
+];

--- a/src/app/features/signup/signup-step1.component.html
+++ b/src/app/features/signup/signup-step1.component.html
@@ -1,0 +1,59 @@
+<section aria-labelledby="signup-heading">
+  <h1 id="signup-heading">Create your account</h1>
+
+  @if (getGeneralError()) {
+    <div role="alert" class="error-banner">{{ getGeneralError() }}</div>
+  }
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <div class="form-field">
+      <label for="email">Email</label>
+      <input
+        id="email"
+        type="email"
+        formControlName="email"
+        autocomplete="email"
+        [attr.aria-describedby]="getFieldError('email') ? 'email-error' : null"
+        [attr.aria-invalid]="getFieldError('email') ? true : null"
+      />
+      @if (getFieldError('email')) {
+        <p id="email-error" role="alert" class="field-error">{{ getFieldError('email') }}</p>
+      }
+    </div>
+
+    <div class="form-field">
+      <label for="password">Password</label>
+      <input
+        id="password"
+        type="password"
+        formControlName="password"
+        autocomplete="new-password"
+        [attr.aria-describedby]="getFieldError('password') ? 'password-error' : null"
+        [attr.aria-invalid]="getFieldError('password') ? true : null"
+      />
+      @if (getFieldError('password')) {
+        <p id="password-error" role="alert" class="field-error">{{ getFieldError('password') }}</p>
+      }
+    </div>
+
+    <div class="form-field">
+      <label for="passwordConfirmation">Confirm password</label>
+      <input
+        #confirmationInput
+        id="passwordConfirmation"
+        type="password"
+        formControlName="passwordConfirmation"
+        autocomplete="new-password"
+        [attr.aria-describedby]="getFieldError('passwordConfirmation') ? 'confirmation-error' : null"
+        [attr.aria-invalid]="getFieldError('passwordConfirmation') ? true : null"
+      />
+      @if (getFieldError('passwordConfirmation')) {
+        <p id="confirmation-error" role="alert" class="field-error">{{ getFieldError('passwordConfirmation') }}</p>
+      }
+    </div>
+
+    <button type="submit" [disabled]="submitting()">
+      {{ submitting() ? 'Creating account...' : 'Sign up' }}
+    </button>
+  </form>
+</section>

--- a/src/app/features/signup/signup-step1.component.spec.ts
+++ b/src/app/features/signup/signup-step1.component.spec.ts
@@ -1,0 +1,192 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter, Router } from '@angular/router';
+import { SignupStep1Component } from './signup-step1.component';
+import { AnalyticsService } from '../../services/analytics.service';
+
+describe('SignupStep1Component', () => {
+  let component: SignupStep1Component;
+  let fixture: ComponentFixture<SignupStep1Component>;
+  let httpMock: HttpTestingController;
+  let analyticsService: AnalyticsService;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SignupStep1Component],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([
+          { path: 'signup/step1', component: SignupStep1Component },
+          { path: 'signup/step2', component: SignupStep1Component },
+        ]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SignupStep1Component);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    analyticsService = TestBed.inject(AnalyticsService);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should require all fields', () => {
+    component.form.markAllAsTouched();
+    expect(component.getFieldError('email')).toBe('Email is required');
+    expect(component.getFieldError('password')).toBe('Password is required');
+    expect(component.getFieldError('passwordConfirmation')).toBe('Password confirmation is required');
+  });
+
+  it('should validate email format', () => {
+    component.form.get('email')?.setValue('not-an-email');
+    component.form.get('email')?.markAsTouched();
+    expect(component.getFieldError('email')).toBe('Invalid email format');
+  });
+
+  it('should validate password minimum length', () => {
+    component.form.get('password')?.setValue('short');
+    component.form.get('password')?.markAsTouched();
+    expect(component.getFieldError('password')).toBe('Password must be between 8 and 128 characters');
+  });
+
+  it('should validate password maximum length', () => {
+    component.form.get('password')?.setValue('a'.repeat(129));
+    component.form.get('password')?.markAsTouched();
+    expect(component.getFieldError('password')).toBe('Password must be between 8 and 128 characters');
+  });
+
+  it('should reject whitespace-only password', () => {
+    component.form.get('password')?.setValue('        ');
+    component.form.get('password')?.markAsTouched();
+    expect(component.getFieldError('password')).toBe('Password cannot be blank');
+  });
+
+  it('should validate password mismatch', () => {
+    component.form.get('password')?.setValue('validpass1');
+    component.form.get('passwordConfirmation')?.setValue('different');
+    component.form.get('passwordConfirmation')?.markAsTouched();
+    expect(component.getFieldError('passwordConfirmation')).toBe('Passwords do not match');
+  });
+
+  it('should not submit when form is invalid', () => {
+    component.onSubmit();
+    httpMock.expectNone('/api/signup/step1');
+  });
+
+  it('should send snake_case request on valid submission', () => {
+    fillValidForm();
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.body).toEqual({
+      email: 'test@example.com',
+      password: 'validpass1',
+      password_confirmation: 'validpass1',
+    });
+    req.flush({ user_id: '123-uuid', step: 1 }, { status: 201, statusText: 'Created' });
+  });
+
+  it('should disable submit button during HTTP call', () => {
+    fillValidForm();
+    component.onSubmit();
+    expect(component.submitting()).toBe(true);
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    req.flush({ user_id: '123-uuid', step: 1 }, { status: 201, statusText: 'Created' });
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('should navigate to step2 on success', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    fillValidForm();
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    req.flush({ user_id: '123-uuid', step: 1 }, { status: 201, statusText: 'Created' });
+    expect(navigateSpy).toHaveBeenCalledWith(['/signup/step2']);
+  });
+
+  it('should track signup attempted with email domain and password length category', () => {
+    fillValidForm();
+    component.onSubmit();
+
+    const events = analyticsService.getEvents();
+    const attempted = events.find((e) => e.name === 'signup_step1_attempted');
+    expect(attempted).toBeTruthy();
+    expect(attempted!.properties['email_domain']).toBe('example.com');
+    expect(attempted!.properties['password_length_category']).toBe('short');
+
+    httpMock.expectOne('/api/signup/step1').flush({ user_id: '123', step: 1 });
+  });
+
+  it('should track signup completed on success', () => {
+    fillValidForm();
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    req.flush({ user_id: 'test-uuid', step: 1 }, { status: 201, statusText: 'Created' });
+
+    const events = analyticsService.getEvents();
+    const completed = events.find((e) => e.name === 'signup_step1_completed');
+    expect(completed).toBeTruthy();
+    expect(completed!.properties['user_id']).toBe('test-uuid');
+  });
+
+  it('should track validation failed for mismatch on client side', () => {
+    component.form.get('email')?.setValue('test@example.com');
+    component.form.get('password')?.setValue('validpass1');
+    component.form.get('passwordConfirmation')?.setValue('differentpass');
+    component.onSubmit();
+
+    const events = analyticsService.getEvents();
+    expect(events.some((e) => e.name === 'signup_validation_failed' && e.properties['error_type'] === 'mismatch')).toBe(true);
+    httpMock.expectNone('/api/signup/step1');
+  });
+
+  it('should apply NFC normalization to passwords in request', () => {
+    // e followed by combining acute accent (NFD) vs precomposed e-acute (NFC)
+    const nfdPassword = 'pa\u0301ssword1';
+    const nfcPassword = nfdPassword.normalize('NFC');
+
+    component.form.get('email')?.setValue('test@example.com');
+    component.form.get('password')?.setValue(nfdPassword);
+    component.form.get('passwordConfirmation')?.setValue(nfdPassword);
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.body['password']).toBe(nfcPassword);
+    expect(req.request.body['password_confirmation']).toBe(nfcPassword);
+    req.flush({ user_id: '123', step: 1 });
+  });
+
+  it('should never include password values in analytics events', () => {
+    fillValidForm();
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    req.flush({ user_id: 'uuid', step: 1 });
+
+    const events = analyticsService.getEvents();
+    for (const event of events) {
+      const props = JSON.stringify(event.properties);
+      expect(props).not.toContain('validpass1');
+    }
+  });
+
+  function fillValidForm(): void {
+    component.form.get('email')?.setValue('test@example.com');
+    component.form.get('password')?.setValue('validpass1');
+    component.form.get('passwordConfirmation')?.setValue('validpass1');
+  }
+});

--- a/src/app/features/signup/signup-step1.component.ts
+++ b/src/app/features/signup/signup-step1.component.ts
@@ -1,0 +1,158 @@
+import { Component, inject, signal, ElementRef, viewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+import { AnalyticsService } from '../../services/analytics.service';
+import { NormalizedApiError, FieldError } from '../../models/api-error.model';
+import { toCamelCase } from '../../utils/case-transform.util';
+
+function passwordMatchValidator(control: AbstractControl): ValidationErrors | null {
+  const password = control.get('password');
+  const confirmation = control.get('passwordConfirmation');
+  if (!password || !confirmation) return null;
+  if (password.value !== confirmation.value) {
+    return { passwordMismatch: true };
+  }
+  return null;
+}
+
+function notBlankValidator(control: AbstractControl): ValidationErrors | null {
+  if (typeof control.value === 'string' && control.value.trim().length === 0 && control.value.length > 0) {
+    return { blank: true };
+  }
+  return null;
+}
+
+@Component({
+  selector: 'app-signup-step1',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './signup-step1.component.html',
+})
+export class SignupStep1Component {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly router = inject(Router);
+
+  readonly confirmationInput = viewChild<ElementRef<HTMLInputElement>>('confirmationInput');
+
+  readonly submitting = signal(false);
+  readonly serverErrors = signal<FieldError[]>([]);
+
+  readonly form: FormGroup = this.fb.group(
+    {
+      email: ['', [Validators.required, Validators.email, Validators.maxLength(255)]],
+      password: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(128), notBlankValidator]],
+      passwordConfirmation: ['', [Validators.required]],
+    },
+    { validators: passwordMatchValidator }
+  );
+
+  getFieldError(field: string): string {
+    // Server errors use snake_case field names; convert to camelCase for matching
+    const serverErr = this.serverErrors().find((e) => toCamelCase(e.field) === field || e.field === field);
+    if (serverErr) return serverErr.message;
+
+    const control = this.form.get(field);
+    if (!control || !control.touched) return '';
+
+    if (control.errors) {
+      if (field === 'email') {
+        if (control.errors['required']) return 'Email is required';
+        if (control.errors['email']) return 'Invalid email format';
+        if (control.errors['maxlength']) return 'Email must be at most 255 characters';
+      }
+
+      if (field === 'password') {
+        if (control.errors['required']) return 'Password is required';
+        if (control.errors['blank']) return 'Password cannot be blank';
+        if (control.errors['minlength']) return 'Password must be between 8 and 128 characters';
+        if (control.errors['maxlength']) return 'Password must be between 8 and 128 characters';
+      }
+
+      if (field === 'passwordConfirmation') {
+        if (control.errors['required']) return 'Password confirmation is required';
+      }
+    }
+
+    if (field === 'passwordConfirmation' && this.form.errors?.['passwordMismatch']) {
+      return 'Passwords do not match';
+    }
+
+    return '';
+  }
+
+  getGeneralError(): string {
+    const general = this.serverErrors().find((e) => e.field === 'general');
+    return general?.message ?? '';
+  }
+
+  onSubmit(): void {
+    this.form.markAllAsTouched();
+    this.serverErrors.set([]);
+
+    if (this.form.invalid) {
+      if (this.form.errors?.['passwordMismatch']) {
+        this.analyticsService.trackSignupValidationFailed('mismatch');
+      }
+      const pw = this.form.get('password');
+      if (pw?.errors?.['blank']) {
+        this.analyticsService.trackSignupValidationFailed('whitespace_only');
+      }
+      if (pw?.errors?.['minlength'] || pw?.errors?.['maxlength']) {
+        this.analyticsService.trackSignupValidationFailed('length');
+      }
+      const email = this.form.get('email');
+      if (email?.errors?.['email'] || email?.errors?.['maxlength']) {
+        this.analyticsService.trackSignupValidationFailed('format');
+      }
+      return;
+    }
+
+    this.submitting.set(true);
+    const { email, password, passwordConfirmation } = this.form.value as {
+      email: string;
+      password: string;
+      passwordConfirmation: string;
+    };
+
+    this.analyticsService.trackSignupAttempted(email, password.length);
+
+    this.authService
+      .signupStep1({ email, password, passwordConfirmation })
+      .subscribe({
+        next: (response) => {
+          this.submitting.set(false);
+          this.analyticsService.trackSignupCompleted(response.userId, response.step);
+          void this.router.navigate(['/signup/step2']);
+        },
+        error: (err: NormalizedApiError) => {
+          this.submitting.set(false);
+          this.serverErrors.set(err.errors);
+
+          if (err.status === 429) {
+            const retrySeconds = err.retryAfter;
+            if (retrySeconds) {
+              this.serverErrors.set([
+                { field: 'general', message: `Too many signup attempts. Please try again in ${retrySeconds} seconds.` },
+              ]);
+            }
+            this.analyticsService.trackRateLimitExceeded(0);
+          } else {
+            for (const e of err.errors) {
+              if (e.field === 'password_confirmation' || e.message.toLowerCase().includes('match')) {
+                this.analyticsService.trackSignupValidationFailed('mismatch');
+                this.form.get('passwordConfirmation')?.reset();
+                const inputEl = this.confirmationInput();
+                if (inputEl) {
+                  inputEl.nativeElement.focus();
+                }
+              }
+            }
+          }
+        },
+      });
+  }
+}

--- a/src/app/interceptors/error.interceptor.spec.ts
+++ b/src/app/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,118 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptors, HttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { errorInterceptor } from './error.interceptor';
+import { NormalizedApiError } from '../models/api-error.model';
+
+describe('errorInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([errorInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('normalizes 400 with structured field errors', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(
+      {
+        detail: [
+          { field: 'password_confirmation', message: 'Passwords do not match' },
+          { field: 'password', message: 'Password must be between 8 and 128 characters' },
+        ],
+      },
+      { status: 400, statusText: 'Bad Request' }
+    );
+
+    expect(err!.status).toBe(400);
+    expect(err!.errors).toEqual([
+      { field: 'password_confirmation', message: 'Passwords do not match' },
+      { field: 'password', message: 'Password must be between 8 and 128 characters' },
+    ]);
+  });
+
+  it('normalizes 409 with string detail', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(
+      { detail: 'An account with this email already exists' },
+      { status: 409, statusText: 'Conflict' }
+    );
+
+    expect(err!.status).toBe(409);
+    expect(err!.errors).toEqual([
+      { field: 'general', message: 'An account with this email already exists' },
+    ]);
+  });
+
+  it('normalizes 429 with Retry-After header', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(
+      { detail: 'Too many signup attempts. Please try again shortly.' },
+      { status: 429, statusText: 'Too Many Requests', headers: { 'Retry-After': '60' } }
+    );
+
+    expect(err!.status).toBe(429);
+    expect(err!.retryAfter).toBe(60);
+    expect(err!.errors[0].message).toBe('Too many signup attempts. Please try again shortly.');
+  });
+
+  it('strips password fields from error detail array', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(
+      {
+        detail: [
+          { field: 'password_confirmation', message: 'Passwords do not match', password: 'secret123' },
+        ],
+      },
+      { status: 400, statusText: 'Bad Request' }
+    );
+
+    const serialized = JSON.stringify(err);
+    expect(serialized).not.toContain('secret123');
+    expect(err!.errors[0].field).toBe('password_confirmation');
+  });
+
+  it('provides fallback error when body is empty', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(null, { status: 500, statusText: 'Server Error' });
+
+    expect(err!.errors).toEqual([{ field: 'general', message: 'An unexpected error occurred' }]);
+  });
+
+  it('handles non-400/409/429 errors too', () => {
+    let err: NormalizedApiError | undefined;
+    http.post('/api/signup/step1', {}).subscribe({ error: (e) => { err = e; } });
+
+    httpMock.expectOne('/api/signup/step1').flush(null, { status: 500, statusText: 'Server Error' });
+
+    expect(err!.status).toBe(500);
+  });
+
+  it('passes successful responses through', () => {
+    let result: unknown;
+    http.post('/api/signup/step1', {}).subscribe({ next: (r) => { result = r; } });
+
+    httpMock.expectOne('/api/signup/step1').flush({ user_id: 'uuid', step: 1 }, { status: 201, statusText: 'Created' });
+
+    expect(result).toEqual({ user_id: 'uuid', step: 1 });
+  });
+});

--- a/src/app/interceptors/error.interceptor.ts
+++ b/src/app/interceptors/error.interceptor.ts
@@ -1,0 +1,54 @@
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { NormalizedApiError, FieldError, WireErrorResponse } from '../models/api-error.model';
+
+const PASSWORD_FIELDS = ['password', 'password_confirmation', 'passwordConfirmation'];
+
+function stripPasswordFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    if (!PASSWORD_FIELDS.includes(key)) {
+      cleaned[key] = obj[key];
+    }
+  }
+  return cleaned;
+}
+
+function normalizeError(response: HttpErrorResponse): NormalizedApiError {
+  const status = response.status;
+  const body = response.error as WireErrorResponse | null;
+  const retryAfterHeader = response.headers?.get('Retry-After');
+  const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
+
+  let errors: FieldError[] = [];
+
+  if (body?.detail) {
+    if (Array.isArray(body.detail)) {
+      errors = body.detail.map((e) => {
+        const cleaned = stripPasswordFields(e as unknown as Record<string, unknown>) as unknown as FieldError;
+        return { field: cleaned.field ?? 'general', message: cleaned.message ?? '' };
+      });
+    } else if (typeof body.detail === 'string') {
+      errors = [{ field: 'general', message: body.detail }];
+    }
+  }
+
+  if (errors.length === 0) {
+    errors = [{ field: 'general', message: 'An unexpected error occurred' }];
+  }
+
+  return { status, errors, retryAfter };
+}
+
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 400 || error.status === 409 || error.status === 429) {
+        const normalized = normalizeError(error);
+        return throwError(() => normalized);
+      }
+      return throwError(() => normalizeError(error));
+    })
+  );
+};

--- a/src/app/models/api-error.model.ts
+++ b/src/app/models/api-error.model.ts
@@ -1,0 +1,14 @@
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface NormalizedApiError {
+  status: number;
+  errors: FieldError[];
+  retryAfter?: number;
+}
+
+export interface WireErrorResponse {
+  detail: string | FieldError[];
+}

--- a/src/app/models/signup.model.ts
+++ b/src/app/models/signup.model.ts
@@ -1,0 +1,21 @@
+export interface SignupStep1Request {
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+export interface SignupStep1WireRequest {
+  email: string;
+  password: string;
+  password_confirmation: string;
+}
+
+export interface SignupStep1Response {
+  userId: string;
+  step: number;
+}
+
+export interface SignupStep1WireResponse {
+  user_id: string;
+  step: number;
+}

--- a/src/app/services/analytics.service.spec.ts
+++ b/src/app/services/analytics.service.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  AnalyticsService,
+  getPasswordLengthCategory,
+  extractEmailDomain,
+  PASSWORD_LENGTH_BUCKETS,
+} from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AnalyticsService);
+  });
+
+  describe('getPasswordLengthCategory', () => {
+    it('returns short for 8-11 chars', () => {
+      expect(getPasswordLengthCategory(8)).toBe('short');
+      expect(getPasswordLengthCategory(11)).toBe('short');
+    });
+    it('returns medium for 12-19 chars', () => {
+      expect(getPasswordLengthCategory(12)).toBe('medium');
+      expect(getPasswordLengthCategory(19)).toBe('medium');
+    });
+    it('returns long for 20+ chars', () => {
+      expect(getPasswordLengthCategory(20)).toBe('long');
+      expect(getPasswordLengthCategory(128)).toBe('long');
+    });
+  });
+
+  describe('extractEmailDomain', () => {
+    it('extracts domain from valid email', () => {
+      expect(extractEmailDomain('user@example.com')).toBe('example.com');
+    });
+    it('returns empty string for invalid email', () => {
+      expect(extractEmailDomain('nope')).toBe('');
+    });
+  });
+
+  describe('trackSignupAttempted', () => {
+    it('records event with email_domain and password_length_category', () => {
+      service.trackSignupAttempted('user@test.io', 10);
+      const events = service.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].name).toBe('signup_step1_attempted');
+      expect(events[0].properties['email_domain']).toBe('test.io');
+      expect(events[0].properties['password_length_category']).toBe('short');
+    });
+
+    it('never includes actual password value in properties', () => {
+      service.trackSignupAttempted('u@x.com', 15);
+      const props = service.getEvents()[0].properties;
+      // Should not have a 'password' key — only 'password_length_category'
+      expect(props).not.toHaveProperty('password');
+      expect(props['password_length_category']).toBe('medium');
+    });
+  });
+
+  describe('trackSignupValidationFailed', () => {
+    it('records mismatch error type', () => {
+      service.trackSignupValidationFailed('mismatch');
+      expect(service.getEvents()[0].properties['error_type']).toBe('mismatch');
+    });
+    it('records whitespace_only error type', () => {
+      service.trackSignupValidationFailed('whitespace_only');
+      expect(service.getEvents()[0].properties['error_type']).toBe('whitespace_only');
+    });
+    it('records length error type', () => {
+      service.trackSignupValidationFailed('length');
+      expect(service.getEvents()[0].properties['error_type']).toBe('length');
+    });
+    it('records format error type', () => {
+      service.trackSignupValidationFailed('format');
+      expect(service.getEvents()[0].properties['error_type']).toBe('format');
+    });
+  });
+
+  describe('trackSignupCompleted', () => {
+    it('records user_id and step', () => {
+      service.trackSignupCompleted('uuid-123', 1);
+      const e = service.getEvents()[0];
+      expect(e.name).toBe('signup_step1_completed');
+      expect(e.properties['user_id']).toBe('uuid-123');
+      expect(e.properties['step']).toBe(1);
+    });
+  });
+
+  describe('trackRateLimitExceeded', () => {
+    it('records attempt_count without IP', () => {
+      service.trackRateLimitExceeded(6);
+      const e = service.getEvents()[0];
+      expect(e.name).toBe('signup_rate_limit_exceeded');
+      expect(e.properties['attempt_count']).toBe(6);
+      expect(e.properties).not.toHaveProperty('ip');
+    });
+  });
+
+  describe('no PII leakage', () => {
+    it('never stores password values across all event types', () => {
+      const password = 'MySecret123!';
+      service.trackSignupAttempted('u@x.com', password.length);
+      service.trackSignupValidationFailed('mismatch');
+      service.trackSignupCompleted('id', 1);
+      service.trackRateLimitExceeded(5);
+
+      const allProps = service.getEvents().map(e => JSON.stringify(e.properties)).join('');
+      expect(allProps).not.toContain(password);
+    });
+  });
+});

--- a/src/app/services/analytics.service.ts
+++ b/src/app/services/analytics.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+
+export const PASSWORD_LENGTH_BUCKETS = {
+  SHORT: 'short',   // 8-11
+  MEDIUM: 'medium', // 12-19
+  LONG: 'long',     // 20+
+} as const;
+
+export type PasswordLengthCategory = typeof PASSWORD_LENGTH_BUCKETS[keyof typeof PASSWORD_LENGTH_BUCKETS];
+
+export function getPasswordLengthCategory(length: number): PasswordLengthCategory {
+  if (length < 12) return PASSWORD_LENGTH_BUCKETS.SHORT;
+  if (length < 20) return PASSWORD_LENGTH_BUCKETS.MEDIUM;
+  return PASSWORD_LENGTH_BUCKETS.LONG;
+}
+
+export function extractEmailDomain(email: string): string {
+  const parts = email.split('@');
+  return parts.length === 2 ? parts[1] : '';
+}
+
+export interface AnalyticsEvent {
+  name: string;
+  properties: Record<string, string | number>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AnalyticsService {
+  private readonly eventLog: AnalyticsEvent[] = [];
+
+  trackSignupAttempted(email: string, passwordLength: number): void {
+    this.track({
+      name: 'signup_step1_attempted',
+      properties: {
+        email_domain: extractEmailDomain(email),
+        password_length_category: getPasswordLengthCategory(passwordLength),
+      },
+    });
+  }
+
+  trackSignupValidationFailed(errorType: string): void {
+    this.track({
+      name: 'signup_validation_failed',
+      properties: { error_type: errorType },
+    });
+  }
+
+  trackSignupCompleted(userId: string, step: number): void {
+    this.track({
+      name: 'signup_step1_completed',
+      properties: { user_id: userId, step },
+    });
+  }
+
+  trackRateLimitExceeded(attemptCount: number): void {
+    this.track({
+      name: 'signup_rate_limit_exceeded',
+      properties: { attempt_count: attemptCount },
+    });
+  }
+
+  getEvents(): readonly AnalyticsEvent[] {
+    return this.eventLog;
+  }
+
+  private track(event: AnalyticsEvent): void {
+    this.eventLog.push(event);
+  }
+}

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('sends snake_case request body', () => {
+    service.signupStep1({
+      email: 'test@example.com',
+      password: 'password1',
+      passwordConfirmation: 'password1',
+    }).subscribe();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      email: 'test@example.com',
+      password: 'password1',
+      password_confirmation: 'password1',
+    });
+    req.flush({ user_id: 'uuid', step: 1 });
+  });
+
+  it('maps snake_case response to camelCase', () => {
+    let result: { userId: string; step: number } | undefined;
+    service.signupStep1({
+      email: 'a@b.com',
+      password: 'password1',
+      passwordConfirmation: 'password1',
+    }).subscribe((res) => { result = res; });
+
+    httpMock.expectOne('/api/signup/step1').flush({ user_id: 'test-uuid', step: 1 });
+    expect(result!.userId).toBe('test-uuid');
+    expect(result!.step).toBe(1);
+  });
+
+  it('applies NFC normalization to password fields', () => {
+    const nfd = 'e\u0301'; // NFD
+    const nfc = nfd.normalize('NFC');
+
+    service.signupStep1({
+      email: 'a@b.com',
+      password: `pass${nfd}`,
+      passwordConfirmation: `pass${nfd}`,
+    }).subscribe();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.body['password']).toBe(`pass${nfc}`);
+    expect(req.request.body['password_confirmation']).toBe(`pass${nfc}`);
+    req.flush({ user_id: 'id', step: 1 });
+  });
+
+  it('handles emoji passwords with NFC normalization', () => {
+    const emojiPass = '🔑secure1';
+    service.signupStep1({
+      email: 'a@b.com',
+      password: emojiPass,
+      passwordConfirmation: emojiPass,
+    }).subscribe();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.body['password']).toBe(emojiPass.normalize('NFC'));
+    req.flush({ user_id: 'id', step: 1 });
+  });
+
+  it('does not modify email (no NFC on email)', () => {
+    service.signupStep1({
+      email: 'Test@Example.COM',
+      password: 'password1',
+      passwordConfirmation: 'password1',
+    }).subscribe();
+
+    const req = httpMock.expectOne('/api/signup/step1');
+    expect(req.request.body['email']).toBe('Test@Example.COM');
+    req.flush({ user_id: 'id', step: 1 });
+  });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { SignupStep1Request, SignupStep1Response, SignupStep1WireResponse } from '../models/signup.model';
+import { mapKeysToSnakeCase } from '../utils/case-transform.util';
+
+function nfcNormalize(value: string): string {
+  return value.normalize('NFC');
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly apiBase = '/api';
+
+  signupStep1(request: SignupStep1Request): Observable<SignupStep1Response> {
+    const normalized: SignupStep1Request = {
+      email: request.email,
+      password: nfcNormalize(request.password),
+      passwordConfirmation: nfcNormalize(request.passwordConfirmation),
+    };
+
+    const wireBody = mapKeysToSnakeCase(normalized as unknown as Record<string, unknown>);
+
+    return this.http
+      .post<SignupStep1WireResponse>(`${this.apiBase}/signup/step1`, wireBody)
+      .pipe(
+        map((wire) => ({
+          userId: wire.user_id,
+          step: wire.step,
+        }))
+      );
+  }
+}

--- a/src/app/utils/case-transform.util.spec.ts
+++ b/src/app/utils/case-transform.util.spec.ts
@@ -1,0 +1,56 @@
+import { toSnakeCase, toCamelCase, mapKeysToSnakeCase, mapKeysToCamelCase } from './case-transform.util';
+
+describe('case-transform.util', () => {
+  describe('toSnakeCase', () => {
+    it('converts camelCase to snake_case', () => {
+      expect(toSnakeCase('passwordConfirmation')).toBe('password_confirmation');
+    });
+    it('leaves already snake_case unchanged', () => {
+      expect(toSnakeCase('password')).toBe('password');
+    });
+    it('handles multiple uppercase letters', () => {
+      expect(toSnakeCase('userId')).toBe('user_id');
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it('converts snake_case to camelCase', () => {
+      expect(toCamelCase('password_confirmation')).toBe('passwordConfirmation');
+    });
+    it('leaves already camelCase unchanged', () => {
+      expect(toCamelCase('password')).toBe('password');
+    });
+    it('handles multiple underscores', () => {
+      expect(toCamelCase('user_id')).toBe('userId');
+    });
+  });
+
+  describe('mapKeysToSnakeCase', () => {
+    it('maps all keys to snake_case', () => {
+      const result = mapKeysToSnakeCase({
+        email: 'test@example.com',
+        password: 'pass',
+        passwordConfirmation: 'pass',
+      });
+      expect(result).toEqual({
+        email: 'test@example.com',
+        password: 'pass',
+        password_confirmation: 'pass',
+      });
+    });
+
+    it('handles empty object', () => {
+      expect(mapKeysToSnakeCase({})).toEqual({});
+    });
+  });
+
+  describe('mapKeysToCamelCase', () => {
+    it('maps all keys to camelCase', () => {
+      const result = mapKeysToCamelCase({
+        user_id: '123',
+        step: 1,
+      });
+      expect(result).toEqual({ userId: '123', step: 1 });
+    });
+  });
+});

--- a/src/app/utils/case-transform.util.ts
+++ b/src/app/utils/case-transform.util.ts
@@ -1,0 +1,27 @@
+export function toSnakeCase(str: string): string {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+export function toCamelCase(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+export function mapKeysToSnakeCase<T extends Record<string, unknown>>(
+  obj: T
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    result[toSnakeCase(key)] = obj[key];
+  }
+  return result;
+}
+
+export function mapKeysToCamelCase<T extends Record<string, unknown>>(
+  obj: T
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    result[toCamelCase(key)] = obj[key];
+  }
+  return result;
+}


### PR DESCRIPTION
## Story
**SAM1-61**: **Hypothesis**

## Acceptance Criteria
- Given a valid email, password (8–128 chars), and matching confirmation, when POST /signup/step1, then return HTTP 201 with user_id (UUID) and step: 1, password stored as Argon2id hash
- Given mismatched password and confirmation fields, when POST /signup/step1, then return HTTP 400 with structured field-level error array including field name and message for each error
- Given multiple validation failures (e.g., short password + mismatch), when POST /signup/step1, then return ALL errors in a single response — do not short-circuit on first failure
- Given passwords with Unicode, emoji, or special characters, when submitted, then NFC normalization is applied before comparison and hashing; round-trip authentication works correctly
- Given a password consisting only of whitespace characters, when POST /signup/step1, then return HTTP 400 with error 'Password cannot be blank'
- Given an email that already exists (any casing variation), when POST /signup/step1, then return HTTP 409 with 'An account with this email already exists' and no additional metadata; uniqueness enforced by DB constraint
- Given more than 5 signup attempts from the same IP within 1 minute, when the next request arrives, then return HTTP 429 with Retry-After header and generic message that does not reveal the rate limit threshold
- Given any request or error scenario, when inspecting response bodies, server logs, error tracking tools, browser console, and analytics events, then zero password values appear anywhere

## Implementation Details
### Architecture


# Technical Architecture Review: Signup Step 1 — Password Validation & User Creation

## Critical Context Mismatch

This story describes a **Python/FastAPI/Pydantic backend** implementation (Pydantic schemas, FastAPI routes, Argon2 hashing, `pyproject.toml`). The target project is an **Angular 21 TypeScript frontend**. These are fundamentally different codebases. I'll provide architecture guidance for **both sides** — the backend contract as specified, and the Angular frontend that will consume it — since the frontend project will inevitably need a service layer and models aligned to this AP

### Developer Notes
**Scope & Ownership**

This story spans two codebases. The backend (Python/FastAPI) owns validation, hashing, persistence, and error responses. The Angular frontend owns the form, service layer, error mapping, and analytics. Both sides can be developed in parallel against the shared API contract. Backend repo and ownership must be confirmed — the Angular side can be built and tested against mocks.

**Backend — Schema & Validation**

- Create `src/schemas/signup.py` with `SignupStep1Request` using Pydantic v2 field validators
- Strip leading/trailing whitespace from email, convert to lowercase 

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/signup/signup-step1.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/signup/signup-step1.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/signup/signup-step1.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/interceptors/error.interceptor.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/interceptors/error.interceptor.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/models/api-error.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/models/signup.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/services/analytics.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/services/analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/services/auth.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/services/auth.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/utils/case-transform.util.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/utils/case-transform.util.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=As a new user, I want to re-enter my password as a confirmation field on step 1 of the signup form, so that I can avoid account lockout caused by accidental typos in my password. -->
<!-- bmad:team_id=SAM1 -->