### PR TITLE
feat(SAM1): As a user, I want to select a country from a list of South A [SAM1-107]

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'countries', pathMatch: 'full' },
+  {
+    path: 'countries',
+    loadComponent: () =>
+      import('./features/countries/countries.component').then(m => m.CountriesComponent),
+  },
+];

--- a/src/app/features/countries/countries-edge-cases.component.spec.ts
+++ b/src/app/features/countries/countries-edge-cases.component.spec.ts
@@ -1,0 +1,248 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CountriesComponent } from './countries.component';
+import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
+
+describe('CountriesComponent — edge cases & additional coverage', () => {
+  let fixture: ComponentFixture<CountriesComponent>;
+  let component: CountriesComponent;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CountriesComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CountriesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    el = fixture.nativeElement;
+  });
+
+  // --- Data model tests ---
+
+  it('should have exactly 12 countries (no French Guiana)', () => {
+    expect(SOUTH_AMERICAN_COUNTRIES.length).toBe(12);
+    const names = SOUTH_AMERICAN_COUNTRIES.map(c => c.name);
+    expect(names).not.toContain('Guayana Francesa');
+    expect(names).not.toContain('French Guiana');
+  });
+
+  it('should have all expected countries in alphabetical order', () => {
+    const expected = [
+      'Argentina', 'Bolivia', 'Brasil', 'Chile', 'Colombia', 'Ecuador',
+      'Guyana', 'Paraguay', 'Perú', 'Surinam', 'Uruguay', 'Venezuela',
+    ];
+    expect(SOUTH_AMERICAN_COUNTRIES.map(c => c.name)).toEqual(expected);
+  });
+
+  it('should have non-empty capital and flag for every country', () => {
+    SOUTH_AMERICAN_COUNTRIES.forEach(c => {
+      expect(c.capital.length).toBeGreaterThan(0);
+      expect(c.flag.length).toBeGreaterThan(0);
+    });
+  });
+
+  // --- selectCountry is no-op in showAll mode ---
+
+  it('should ignore selectCountry calls when in show-all mode', () => {
+    component.showAll.set(true);
+    component.selectCountry('Argentina');
+    expect(component.selectedCountry()).toBeNull();
+  });
+
+  // --- Keyboard: ArrowDown / ArrowUp navigation ---
+
+  it('should move focusedIndex down on ArrowDown', () => {
+    expect(component.focusedIndex()).toBe(0);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+    component.onCountryKeydown(event, 0);
+    expect(component.focusedIndex()).toBe(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should move focusedIndex up on ArrowUp', () => {
+    component.focusedIndex.set(5);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true });
+    component.onCountryKeydown(event, 5);
+    expect(component.focusedIndex()).toBe(4);
+  });
+
+  it('should not move focus below last item', () => {
+    component.focusedIndex.set(11);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+    component.onCountryKeydown(event, 11);
+    expect(component.focusedIndex()).toBe(11);
+  });
+
+  it('should not move focus above first item', () => {
+    component.focusedIndex.set(0);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true });
+    component.onCountryKeydown(event, 0);
+    expect(component.focusedIndex()).toBe(0);
+  });
+
+  // --- Roving tabindex ---
+
+  it('should have tabindex 0 only on focused row and -1 on others', () => {
+    const rows = el.querySelectorAll('.country-row');
+    expect(rows[0].getAttribute('tabindex')).toBe('0');
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].getAttribute('tabindex')).toBe('-1');
+    }
+
+    // Move focus to index 3
+    component.focusedIndex.set(3);
+    fixture.detectChanges();
+    expect(rows[3].getAttribute('tabindex')).toBe('0');
+    expect(rows[0].getAttribute('tabindex')).toBe('-1');
+  });
+
+  // --- aria-expanded on all rows ---
+
+  it('should set aria-expanded false on all unselected rows', () => {
+    const rows = el.querySelectorAll('.country-row');
+    rows.forEach(row => {
+      expect(row.getAttribute('aria-expanded')).toBe('false');
+    });
+  });
+
+  // --- capital-reveal-wrapper aria-hidden ---
+
+  it('should set aria-hidden true on all capital wrappers when none selected', () => {
+    const wrappers = el.querySelectorAll('.capital-reveal-wrapper');
+    wrappers.forEach(w => {
+      expect(w.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  it('should set aria-hidden false only on selected country capital wrapper', () => {
+    const rows = el.querySelectorAll('.country-row');
+    (rows[2] as HTMLElement).click();
+    fixture.detectChanges();
+
+    const wrappers = el.querySelectorAll('.capital-reveal-wrapper');
+    wrappers.forEach((w, i) => {
+      if (i === 2) {
+        expect(w.getAttribute('aria-hidden')).toBe('false');
+      } else {
+        expect(w.getAttribute('aria-hidden')).toBe('true');
+      }
+    });
+  });
+
+  // --- Show-all table semantics ---
+
+  it('should have proper table headers with scope=col in show-all mode', () => {
+    component.showAll.set(true);
+    fixture.detectChanges();
+
+    const ths = el.querySelectorAll('th');
+    expect(ths.length).toBe(2);
+    expect(ths[0].textContent?.trim()).toBe('País');
+    expect(ths[1].textContent?.trim()).toBe('Capital');
+    ths.forEach(th => expect(th.getAttribute('scope')).toBe('col'));
+  });
+
+  // --- Checkmark only on selected row ---
+
+  it('should show checkmark only on selected country row', () => {
+    expect(el.querySelectorAll('.checkmark').length).toBe(0);
+
+    const rows = el.querySelectorAll('.country-row');
+    (rows[0] as HTMLElement).click();
+    fixture.detectChanges();
+
+    const checkmarks = el.querySelectorAll('.checkmark');
+    expect(checkmarks.length).toBe(1);
+    expect(checkmarks[0].closest('.country-row')).toBe(rows[0]);
+  });
+
+  // --- Selected class toggling ---
+
+  it('should apply selected class only to the selected row', () => {
+    const rows = el.querySelectorAll('.country-row');
+    (rows[6] as HTMLElement).click(); // Guyana
+    fixture.detectChanges();
+
+    expect(rows[6].classList.contains('selected')).toBe(true);
+    for (let i = 0; i < rows.length; i++) {
+      if (i !== 6) {
+        expect(rows[i].classList.contains('selected')).toBe(false);
+      }
+    }
+  });
+
+  // --- Announcement text computed signal ---
+
+  it('should return empty string for announcementText when no selection', () => {
+    expect(component.announcementText()).toBe('');
+  });
+
+  it('should return correct announcement for each country', () => {
+    component.selectedCountry.set('Perú');
+    expect(component.announcementText()).toBe('Capital: Lima');
+  });
+
+  it('should return empty string for announcementText with invalid country name', () => {
+    component.selectedCountry.set('Atlantis');
+    expect(component.announcementText()).toBe('');
+  });
+
+  // --- toggleShowAll clears selection from any state ---
+
+  it('should clear selection when toggling from explore to show-all and back', () => {
+    component.selectedCountry.set('Chile');
+    component.toggleShowAll(); // → show_all
+    expect(component.selectedCountry()).toBeNull();
+    expect(component.showAll()).toBe(true);
+
+    component.toggleShowAll(); // → explore
+    expect(component.selectedCountry()).toBeNull();
+    expect(component.showAll()).toBe(false);
+  });
+
+  // --- Rapid toggle between modes ---
+
+  it('should handle rapid mode toggles without errors', () => {
+    const btn = el.querySelector('.toggle-btn') as HTMLElement;
+    btn.click(); btn.click(); btn.click();
+    fixture.detectChanges();
+    // Odd number of clicks → show_all
+    expect(component.showAll()).toBe(true);
+    expect(component.selectedCountry()).toBeNull();
+  });
+
+  // --- aria-live region present in both modes ---
+
+  it('should have aria-live region present in show-all mode', () => {
+    component.showAll.set(true);
+    fixture.detectChanges();
+    expect(el.querySelector('[data-testid="live-region"]')).not.toBeNull();
+  });
+
+  // --- heading landmark ---
+
+  it('should have section with aria-labelledby pointing to heading', () => {
+    const section = el.querySelector('section');
+    expect(section?.getAttribute('aria-labelledby')).toBe('countries-heading');
+    expect(el.querySelector('#countries-heading')?.tagName).toBe('H2');
+  });
+
+  // --- country rows have role=button ---
+
+  it('should have role=button on each country row', () => {
+    const rows = el.querySelectorAll('.country-row');
+    rows.forEach(row => {
+      expect(row.getAttribute('role')).toBe('button');
+    });
+  });
+
+  // --- Unrecognized keys are ignored ---
+
+  it('should not change state on unrecognized keydown', () => {
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    component.onCountryKeydown(event, 0);
+    expect(component.selectedCountry()).toBeNull();
+    expect(component.focusedIndex()).toBe(0);
+  });
+});

--- a/src/app/features/countries/countries.component.spec.ts
+++ b/src/app/features/countries/countries.component.spec.ts
@@ -1,0 +1,195 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CountriesComponent } from './countries.component';
+import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
+
+describe('CountriesComponent', () => {
+  let fixture: ComponentFixture<CountriesComponent>;
+  let component: CountriesComponent;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CountriesComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CountriesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    el = fixture.nativeElement;
+  });
+
+  it('should render all 12 countries alphabetically with placeholder and heading', () => {
+    const rows = el.querySelectorAll('.country-row');
+    expect(rows.length).toBe(12);
+
+    // Verify alphabetical order
+    const names = Array.from(rows).map(r => r.textContent?.trim().replace(/^[^\w]*/, ''));
+    for (let i = 1; i < names.length; i++) {
+      expect(names[i]! >= names[i - 1]!).toBe(true);
+    }
+
+    // Heading
+    expect(el.querySelector('h2')?.textContent).toContain('Capitales de Sudam\u00e9rica');
+
+    // Toggle button
+    const btn = el.querySelector('.toggle-btn');
+    expect(btn?.textContent?.trim()).toBe('Ver todas las capitales');
+
+    // Placeholder
+    expect(el.querySelector('.placeholder')?.textContent).toContain('Selecciona un pa\u00eds para ver su capital');
+
+    // No capital visible
+    const openWrappers = el.querySelectorAll('.capital-reveal-wrapper.open');
+    expect(openWrappers.length).toBe(0);
+  });
+
+  it('should display flag emojis for each country', () => {
+    const rows = el.querySelectorAll('.country-row');
+    rows.forEach((row, i) => {
+      expect(row.textContent).toContain(SOUTH_AMERICAN_COUNTRIES[i].flag);
+    });
+  });
+
+  it('should reveal capital on country selection with aria-expanded', () => {
+    const rows = el.querySelectorAll('.country-row');
+    // Click Colombia (index 4)
+    (rows[4] as HTMLElement).click();
+    fixture.detectChanges();
+
+    expect(component.selectedCountry()).toBe('Colombia');
+    expect(rows[4].getAttribute('aria-expanded')).toBe('true');
+    expect(rows[4].querySelector('.capital-reveal-wrapper')?.classList.contains('open')).toBe(true);
+    expect(rows[4].textContent).toContain('Bogot\u00e1');
+
+    // Placeholder gone
+    expect(el.querySelector('.placeholder')).toBeNull();
+  });
+
+  it('should toggle deselect and restore placeholder', () => {
+    const rows = el.querySelectorAll('.country-row');
+    (rows[4] as HTMLElement).click();
+    fixture.detectChanges();
+    (rows[4] as HTMLElement).click();
+    fixture.detectChanges();
+
+    expect(component.selectedCountry()).toBeNull();
+    expect(rows[4].getAttribute('aria-expanded')).toBe('false');
+    expect(rows[4].querySelector('.capital-reveal-wrapper')?.classList.contains('open')).toBe(false);
+    expect(el.querySelector('.placeholder')).not.toBeNull();
+  });
+
+  it('should switch selection between countries', () => {
+    const rows = el.querySelectorAll('.country-row');
+    // Select Colombia
+    (rows[4] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(rows[4].textContent).toContain('Bogot\u00e1');
+
+    // Select Chile (index 3)
+    (rows[3] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(component.selectedCountry()).toBe('Chile');
+    expect(rows[3].querySelector('.capital-reveal-wrapper')?.classList.contains('open')).toBe(true);
+    expect(rows[3].textContent).toContain('Santiago');
+    // Previous collapsed
+    expect(rows[4].querySelector('.capital-reveal-wrapper')?.classList.contains('open')).toBe(false);
+  });
+
+  it('should show all capitals in table mode', () => {
+    const btn = el.querySelector('.toggle-btn') as HTMLElement;
+    btn.click();
+    fixture.detectChanges();
+
+    expect(component.showAll()).toBe(true);
+    const table = el.querySelector('table');
+    expect(table).not.toBeNull();
+
+    const thElements = table!.querySelectorAll('th');
+    expect(thElements.length).toBe(2);
+    expect(thElements[0].getAttribute('scope')).toBe('col');
+
+    const tbodyRows = table!.querySelectorAll('tbody tr');
+    expect(tbodyRows.length).toBe(12);
+
+    // Each row has flag
+    tbodyRows.forEach((row, i) => {
+      expect(row.textContent).toContain(SOUTH_AMERICAN_COUNTRIES[i].flag);
+      expect(row.textContent).toContain(SOUTH_AMERICAN_COUNTRIES[i].capital);
+    });
+
+    // Button label changed
+    expect(btn.textContent?.trim()).toBe('Explorar una por una');
+  });
+
+  it('should return to explore mode with no pre-selection', () => {
+    const btn = el.querySelector('.toggle-btn') as HTMLElement;
+    btn.click();
+    fixture.detectChanges();
+    btn.click();
+    fixture.detectChanges();
+
+    expect(component.showAll()).toBe(false);
+    expect(component.selectedCountry()).toBeNull();
+    expect(el.querySelector('table')).toBeNull();
+    expect(el.querySelectorAll('.country-row').length).toBe(12);
+    expect(el.querySelector('.placeholder')).not.toBeNull();
+  });
+
+  it('should clear selection when toggling to show-all', () => {
+    const rows = el.querySelectorAll('.country-row');
+    (rows[0] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(component.selectedCountry()).toBe('Argentina');
+
+    (el.querySelector('.toggle-btn') as HTMLElement).click();
+    fixture.detectChanges();
+    expect(component.selectedCountry()).toBeNull();
+  });
+
+  it('should select country on keyboard Enter', () => {
+    const rows = el.querySelectorAll('.country-row');
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    rows[2].dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.selectedCountry()).toBe('Brasil');
+  });
+
+  it('should select country on keyboard Space and prevent default', () => {
+    const rows = el.querySelectorAll('.country-row');
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    rows[5].dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.selectedCountry()).toBe('Ecuador');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should update aria-live region on selection and clear on deselect', () => {
+    const liveRegion = el.querySelector('[data-testid="live-region"]')!;
+    expect(liveRegion.textContent?.trim()).toBe('');
+
+    const rows = el.querySelectorAll('.country-row');
+    (rows[0] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(liveRegion.textContent?.trim()).toBe('Capital: Buenos Aires');
+
+    (rows[0] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(liveRegion.textContent?.trim()).toBe('');
+  });
+
+  it('should resolve rapid clicks to last selection only', () => {
+    // Click three countries without intermediate detectChanges
+    const rows = el.querySelectorAll('.country-row');
+    (rows[0] as HTMLElement).click();
+    (rows[3] as HTMLElement).click();
+    (rows[7] as HTMLElement).click();
+    fixture.detectChanges();
+
+    expect(component.selectedCountry()).toBe('Paraguay');
+    const openWrappers = el.querySelectorAll('.capital-reveal-wrapper.open');
+    expect(openWrappers.length).toBe(1);
+    expect(openWrappers[0].textContent).toContain('Asunci\u00f3n');
+  });
+});

--- a/src/app/features/countries/countries.component.ts
+++ b/src/app/features/countries/countries.component.ts
@@ -1,0 +1,313 @@
+import { Component, computed, signal, viewChildren, ElementRef, WritableSignal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Country, SOUTH_AMERICAN_COUNTRIES } from './country.model';
+
+@Component({
+  selector: 'app-countries',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <section class="countries-card" aria-labelledby="countries-heading">
+      <div class="card-header">
+        <h2 id="countries-heading">Capitales de Sudam\u00e9rica</h2>
+        <button
+          type="button"
+          class="toggle-btn"
+          (click)="toggleShowAll()">
+          {{ showAll() ? 'Explorar una por una' : 'Ver todas las capitales' }}
+        </button>
+      </div>
+
+      <!-- Persistent aria-live region for screen reader announcements -->
+      <div aria-live="polite" class="sr-only" data-testid="live-region">{{ announcementText() }}</div>
+
+      @if (showAll()) {
+        <table class="capitals-table">
+          <thead>
+            <tr>
+              <th scope="col">Pa\u00eds</th>
+              <th scope="col">Capital</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (country of countries; track country.name) {
+              <tr>
+                <td>{{ country.flag }} {{ country.name }}</td>
+                <td>{{ country.capital }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      } @else {
+        @if (!selectedCountry()) {
+          <p class="placeholder">Selecciona un pa\u00eds para ver su capital</p>
+        }
+
+        <ul role="list" class="country-list">
+          @for (country of countries; track country.name; let i = $index) {
+            <li
+              #countryRow
+              class="country-row"
+              [class.selected]="selectedCountry() === country.name"
+              role="button"
+              [attr.tabindex]="focusedIndex() === i ? 0 : -1"
+              [attr.aria-expanded]="selectedCountry() === country.name"
+              (click)="selectCountry(country.name)"
+              (keydown)="onCountryKeydown($event, i)">
+              <span class="country-label">
+                @if (selectedCountry() === country.name) {
+                  <span class="checkmark" aria-hidden="true">\u2713</span>
+                }
+                {{ country.flag }} {{ country.name }}
+              </span>
+              <div
+                class="capital-reveal-wrapper"
+                [class.open]="selectedCountry() === country.name"
+                [attr.aria-hidden]="selectedCountry() !== country.name">
+                <div class="capital-reveal-inner">
+                  <span class="capital-text">Capital: {{ country.capital }}</span>
+                </div>
+              </div>
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      padding: 1rem;
+    }
+
+    .countries-card {
+      max-width: 600px;
+      margin: 0 auto;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      overflow: hidden;
+      background: #fff;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid #eee;
+    }
+
+    .card-header h2 {
+      margin: 0;
+      font-size: 1.25rem;
+    }
+
+    .toggle-btn {
+      padding: 0.5rem 1rem;
+      border: 1px solid #0066cc;
+      border-radius: 4px;
+      background: #fff;
+      color: #0066cc;
+      cursor: pointer;
+      font-size: 0.875rem;
+      white-space: nowrap;
+    }
+
+    .toggle-btn:hover {
+      background: #f0f6ff;
+    }
+
+    .toggle-btn:focus-visible {
+      outline: 2px solid #0066cc;
+      outline-offset: 2px;
+    }
+
+    .placeholder {
+      padding: 0.75rem 1.25rem;
+      margin: 0;
+      color: #666;
+      font-style: italic;
+      font-size: 0.9rem;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    /* Country list */
+    .country-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .country-row {
+      min-height: 48px;
+      padding: 0.75rem 1.25rem;
+      cursor: pointer;
+      border-left: 4px solid transparent;
+      user-select: none;
+    }
+
+    .country-row:not(:last-child) {
+      border-bottom: 1px solid #f0f0f0;
+    }
+
+    .country-row:hover {
+      background: #f8f9fa;
+    }
+
+    .country-row:focus-visible {
+      outline: 2px solid #0066cc;
+      outline-offset: -2px;
+    }
+
+    .country-row.selected {
+      border-left-color: #0066cc;
+      background: #f0f6ff;
+    }
+
+    .country-label {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 1rem;
+    }
+
+    .checkmark {
+      color: #0066cc;
+      font-weight: bold;
+      margin-right: 0.25rem;
+    }
+
+    /* Capital reveal animation using grid technique */
+    .capital-reveal-wrapper {
+      display: grid;
+      grid-template-rows: 0fr;
+      visibility: hidden;
+    }
+
+    .capital-reveal-wrapper.open {
+      grid-template-rows: 1fr;
+      visibility: visible;
+    }
+
+    .capital-reveal-inner {
+      overflow: hidden;
+    }
+
+    .capital-text {
+      display: block;
+      padding: 0.5rem 0 0.25rem 1.75rem;
+      color: #444;
+      font-size: 0.9rem;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .capital-reveal-wrapper {
+        transition: grid-template-rows 180ms ease-out, visibility 0s linear 180ms;
+      }
+      .capital-reveal-wrapper.open {
+        transition: grid-template-rows 180ms ease-out, visibility 0s linear 0s;
+      }
+    }
+
+    /* Table mode */
+    .capitals-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .capitals-table th {
+      text-align: left;
+      padding: 0.75rem 1.25rem;
+      background: #f8f9fa;
+      font-size: 0.875rem;
+      color: #555;
+      border-bottom: 2px solid #ddd;
+    }
+
+    .capitals-table td {
+      padding: 0.625rem 1.25rem;
+      font-size: 0.95rem;
+    }
+
+    .capitals-table tbody tr:nth-child(even) {
+      background: #f9fafb;
+    }
+
+    .capitals-table tbody tr:not(:last-child) td {
+      border-bottom: 1px solid #f0f0f0;
+    }
+  `]
+})
+export class CountriesComponent {
+  private readonly countryRows = viewChildren<ElementRef<HTMLElement>>('countryRow');
+  readonly countries: readonly Country[] = SOUTH_AMERICAN_COUNTRIES;
+  readonly selectedCountry: WritableSignal<string | null> = signal(null);
+  readonly showAll: WritableSignal<boolean> = signal(false);
+  readonly focusedIndex: WritableSignal<number> = signal(0);
+
+  readonly announcementText = computed(() => {
+    const name = this.selectedCountry();
+    if (!name) return '';
+    const country = this.countries.find(c => c.name === name);
+    return country ? `Capital: ${country.capital}` : '';
+  });
+
+  selectCountry(name: string): void {
+    if (this.showAll()) return;
+    // TODO: emit analytics event — country_selected { country_name, capital_name } or country_deselected { country_name }
+    if (this.selectedCountry() === name) {
+      this.selectedCountry.set(null);
+    } else {
+      this.selectedCountry.set(name);
+    }
+  }
+
+  toggleShowAll(): void {
+    const previousMode = this.showAll() ? 'show_all' : 'explore';
+    this.showAll.update(v => !v);
+    this.selectedCountry.set(null);
+    // TODO: emit analytics event — show_all_toggled { mode: this.showAll() ? 'show_all' : 'explore', previous_mode: previousMode }
+  }
+
+  onCountryKeydown(event: KeyboardEvent, index: number): void {
+    switch (event.key) {
+      case 'Enter':
+        this.selectCountry(this.countries[index].name);
+        break;
+      case ' ':
+        event.preventDefault();
+        this.selectCountry(this.countries[index].name);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        this.moveFocus(index + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.moveFocus(index - 1);
+        break;
+    }
+  }
+
+  private moveFocus(newIndex: number): void {
+    if (newIndex < 0 || newIndex >= this.countries.length) return;
+    this.focusedIndex.set(newIndex);
+    // Focus the DOM element after Angular updates tabindex
+    setTimeout(() => {
+      const rows = this.countryRows();
+      rows[newIndex]?.nativeElement.focus();
+    });
+  }
+}

--- a/src/app/features/countries/country.model.ts
+++ b/src/app/features/countries/country.model.ts
@@ -1,0 +1,22 @@
+export interface Country {
+  name: string;
+  capital: string;
+  flag: string;
+}
+
+// French Guiana (Guayana Francesa) is intentionally excluded.
+// It is an overseas territory of France, not a sovereign state.
+export const SOUTH_AMERICAN_COUNTRIES: readonly Country[] = [
+  { name: 'Argentina', capital: 'Buenos Aires', flag: '\u{1F1E6}\u{1F1F7}' },
+  { name: 'Bolivia', capital: 'Sucre', flag: '\u{1F1E7}\u{1F1F4}' },
+  { name: 'Brasil', capital: 'Brasilia', flag: '\u{1F1E7}\u{1F1F7}' },
+  { name: 'Chile', capital: 'Santiago', flag: '\u{1F1E8}\u{1F1F1}' },
+  { name: 'Colombia', capital: 'Bogot\u00e1', flag: '\u{1F1E8}\u{1F1F4}' },
+  { name: 'Ecuador', capital: 'Quito', flag: '\u{1F1EA}\u{1F1E8}' },
+  { name: 'Guyana', capital: 'Georgetown', flag: '\u{1F1EC}\u{1F1FE}' },
+  { name: 'Paraguay', capital: 'Asunci\u00f3n', flag: '\u{1F1F5}\u{1F1FE}' },
+  { name: 'Per\u00fa', capital: 'Lima', flag: '\u{1F1F5}\u{1F1EA}' },
+  { name: 'Surinam', capital: 'Paramaribo', flag: '\u{1F1F8}\u{1F1F7}' },
+  { name: 'Uruguay', capital: 'Montevideo', flag: '\u{1F1FA}\u{1F1FE}' },
+  { name: 'Venezuela', capital: 'Caracas', flag: '\u{1F1FB}\u{1F1EA}' },
+];


### PR DESCRIPTION
## Story
**SAM1-107**: **Hypothesis**

## Acceptance Criteria
- **Given** the user navigates to `/countries` **When** the page renders **Then** all 12 sovereign South American countries are displayed alphabetically with flag emojis, the heading 'Capitales de Sudamérica' is visible, the toggle button 'Ver todas las capitales' is visible above the list, and the placeholder text 'Selecciona un país para ver su capital' is shown.
- **Given** no country is selected **When** the user clicks a country **Then** the capital city appears inline beneath that country with a slide-down animation under 200 ms, the country row is visually highlighted (left-border accent + background tint + checkmark), and the aria-live region announces 'Capital: [city]'.
- **Given** a country is already selected **When** the user clicks the same country again **Then** the capital collapses with a slide-up animation, the highlight clears, and the placeholder text is restored.
- **Given** a country is selected **When** the user clicks a different country **Then** the previous capital is dismissed, the new capital is shown, and the highlight moves to the new country with no intermediate blank flash.
- **Given** the user is in explore mode **When** the user clicks 'Ver todas las capitales' **Then** any active selection is cleared immediately, all 12 countries with flag emojis and their capitals are displayed in a two-column table with proper table semantics, and the button label changes to 'Explorar una por una'.
- **Given** the user is navigating via keyboard **When** they Tab to the list, use Arrow Up/Down to move between rows, and press Enter or Space **Then** the country is selected, the capital is revealed, focus stays on the row, Space does not scroll the page, and a visible focus ring is present at all times.
- **Given** a screen reader is active **When** a country is selected **Then** the capital is announced via a persistent aria-live='polite' region containing only 'Capital: [city]' (no duplicate country name), and when deselected the region is emptied.
- **Given** the user clicks multiple countries in quick succession **When** the UI updates **Then** only the most recently selected country's capital is displayed, CSS transitions are interruptible without stacking or flickering, and no stale data is shown.

## Implementation Details
### Architecture


# Technical Architecture Review: South American Countries Explorer

## Data Model

Define the `Country` interface and static dataset in `src/app/features/countries/country.model.ts`. The interface is intentionally minimal — no `id` field is needed because `name` is unique within this 12-element dataset and serves as the selection key.

```typescript
export interface Country {
  name: string;    // Spanish common short name, e.g. "Argentina"
  capital: string; // Spanish common short name, e.g. "Buenos Aires"
  flag: string;    // Single emoji codepoint, e.g. "🇦🇷"
}
```

The `SOUTH_AMERICAN_C

### Developer Notes
**Data Model — `src/app/features/countries/country.model.ts`**

- `Country` interface: `{ name: string; capital: string; flag: string }`
- `SOUTH_AMERICAN_COUNTRIES` as a `readonly Country[]`, pre-sorted alphabetically by `name`. All values in Spanish common short names.
- The 12 countries: Argentina, Bolivia, Brasil, Chile, Colombia, Ecuador, Guyana, Paraguay, Perú, Surinam, Uruguay, Venezuela.
- French Guiana exclusion comment placed directly above the array declaration.

**Component — `src/app/features/countries/countries.component.ts`**

- Standalone component with `standalone: true`, impo

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries-edge-cases.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/country.model.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=As a user, I want to select a country from a list of South American countries and see its corresponding capital displayed, so that I can quickly look up capital cities by country. -->
<!-- bmad:team_id=SAM1 -->