### PR TITLE
feat(SAM1): As a user, I want to select a country from a list of South A [SAM1-107]

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,12 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'countries', pathMatch: 'full' },
+  {
+    path: 'countries',
+    loadComponent: () =>
+      import('./features/countries/countries.component').then(
+        (m) => m.CountriesComponent
+      ),
+  },
+];

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { App } from './app';
 
 describe('App', () => {
+  setupTestBed();
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],

--- a/src/app/features/countries/countries.component.css
+++ b/src/app/features/countries/countries.component.css
@@ -1,0 +1,214 @@
+/* ===== Utility ===== */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ===== Card ===== */
+.card {
+  max-width: 540px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* ===== Header ===== */
+.card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+/* ===== Toggle Button ===== */
+.toggle-btn {
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  border: 1.5px solid #4361ee;
+  background: transparent;
+  color: #4361ee;
+  white-space: nowrap;
+}
+
+.toggle-btn--show-all {
+  background: #4361ee;
+  color: #fff;
+}
+
+.toggle-btn:focus-visible {
+  outline: 2px solid #4361ee;
+  outline-offset: 2px;
+}
+
+/* ===== Placeholder ===== */
+.placeholder {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+  opacity: 1;
+}
+
+.placeholder--hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ===== Country List ===== */
+.country-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.country-row {
+  display: block;
+  width: 100%;
+  min-height: 48px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-left: 4px solid transparent;
+  border-radius: 4px;
+}
+
+.country-row:focus-visible {
+  outline: 2px solid #4361ee;
+  outline-offset: 2px;
+}
+
+.country-row--selected {
+  border-left-color: #4361ee;
+  background: #eef2ff;
+}
+
+.country-row__content {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 0.5rem 0.75rem;
+  gap: 0.5rem;
+}
+
+.country-row__flag {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.country-row__name {
+  flex: 1;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #1a1a2e;
+}
+
+.country-row__check {
+  color: #4361ee;
+  margin-right: 0.25rem;
+  font-weight: 700;
+}
+
+.country-row__chevron {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: #6b7280;
+  display: inline-block;
+}
+
+.country-row__chevron--open {
+  transform: rotate(90deg);
+}
+
+/* ===== Capital Wrapper — always in DOM, animated via CSS class ===== */
+.capital-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.capital-wrapper.open {
+  grid-template-rows: 1fr;
+  visibility: visible;
+}
+
+.capital-wrapper__inner {
+  overflow: hidden;
+}
+
+.capital-text {
+  display: block;
+  padding: 0 0.75rem 10px 2rem;
+  font-size: 0.875rem;
+  color: #4361ee;
+  font-weight: 600;
+}
+
+/* ===== Show-All Table ===== */
+.capitals-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.capitals-table thead th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  color: #1a1a2e;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.capitals-table__row {
+  cursor: default;
+}
+
+.capitals-table__row:nth-child(even) {
+  background: #f9fafb;
+}
+
+.capitals-table__row td {
+  padding: 0.5rem 0.75rem;
+  color: #374151;
+}
+
+/* ===== Animations — only when user has no motion preference ===== */
+@media (prefers-reduced-motion: no-preference) {
+  .capital-wrapper {
+    transition: grid-template-rows 180ms ease-out, visibility 0s 180ms;
+  }
+
+  .capital-wrapper.open {
+    transition: grid-template-rows 180ms ease-out, visibility 0s 0s;
+  }
+
+  .placeholder {
+    transition: opacity 180ms ease-out;
+  }
+
+  .country-row__chevron {
+    transition: transform 180ms ease-out;
+  }
+}

--- a/src/app/features/countries/countries.component.css
+++ b/src/app/features/countries/countries.component.css
@@ -20,6 +20,8 @@
   background: #fff;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
   font-family: system-ui, -apple-system, sans-serif;
+  /* Prevent visual collapse during @if structural swap between modes */
+  min-height: 640px;
 }
 
 /* ===== Header ===== */
@@ -113,6 +115,9 @@
 }
 
 .country-row__flag {
+  min-width: 1.5em;
+  text-align: center;
+  display: inline-block;
   font-size: 1.25rem;
   flex-shrink: 0;
 }
@@ -192,6 +197,13 @@
 .capitals-table__row td {
   padding: 0.5rem 0.75rem;
   color: #374151;
+}
+
+/* ===== Table flag emoji container ===== */
+.table-flag {
+  min-width: 1.5em;
+  text-align: center;
+  display: inline-block;
 }
 
 /* ===== Animations — only when user has no motion preference ===== */

--- a/src/app/features/countries/countries.component.edge.spec.ts
+++ b/src/app/features/countries/countries.component.edge.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { CountriesComponent } from './countries.component';
 import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
 
 describe('CountriesComponent — edge cases & failure modes', () => {
+  setupTestBed();
+
   let fixture: ComponentFixture<CountriesComponent>;
   let component: CountriesComponent;
   let el: HTMLElement;
@@ -113,7 +116,6 @@ describe('CountriesComponent — edge cases & failure modes', () => {
   // ===== Checkmark on selection =====
   describe('checkmark indicator', () => {
     it('should show checkmark on selected row only', () => {
-      // Verify no row has a checkmark before selection
       const rowsBefore = el.querySelectorAll('.country-row');
       rowsBefore.forEach((row) => {
         expect(row.querySelector('.country-row__check')).toBeNull();
@@ -123,7 +125,6 @@ describe('CountriesComponent — edge cases & failure modes', () => {
       rows[0].click();
       fixture.detectChanges();
 
-      // Verify only the selected row contains a checkmark
       const updatedRows = el.querySelectorAll('.country-row');
       updatedRows.forEach((row, i) => {
         const check = row.querySelector('.country-row__check');
@@ -181,7 +182,7 @@ describe('CountriesComponent — edge cases & failure modes', () => {
     it('should clear selection and switch to table cleanly', () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       rows[4].click(); // Colombia
-      fixture.detectChanges(); // Ensure selection state is applied before toggling mid-animation
+      fixture.detectChanges();
 
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
@@ -194,21 +195,26 @@ describe('CountriesComponent — edge cases & failure modes', () => {
     });
   });
 
-  // ===== liveRegionText computed signal =====
+  // ===== liveRegionText computed signal (tested via DOM) =====
   describe('liveRegionText signal', () => {
     it('should return empty string when no selection and no announcement', () => {
-      expect((component as any).liveRegionText()).toBe('');
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent?.trim()).toBe('');
     });
 
     it('should return capital text when a country is selected', () => {
       component.selectCountry('Perú');
-      expect((component as any).liveRegionText()).toBe('Capital: Lima');
+      fixture.detectChanges();
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Capital: Lima');
     });
 
     it('should prioritize modeAnnouncement over capital text', () => {
       component.selectCountry('Chile');
       component.modeAnnouncement.set('Mostrando todas las capitales');
-      expect((component as any).liveRegionText()).toBe('Mostrando todas las capitales');
+      fixture.detectChanges();
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Mostrando todas las capitales');
     });
   });
 
@@ -264,10 +270,8 @@ describe('CountriesComponent — edge cases & failure modes', () => {
       btn.click();
       fixture.detectChanges();
 
-      // Verify no country-row elements exist (table uses different markup)
       expect(el.querySelectorAll('.country-row').length).toBe(0);
 
-      // Table rows exist
       const tableRows = el.querySelectorAll('.capitals-table__row');
       expect(tableRows.length).toBe(12);
     });
@@ -301,21 +305,27 @@ describe('CountriesComponent — edge cases & failure modes', () => {
   // ===== Double toggle show-all restores explore with no pre-selection =====
   describe('double toggle show-all', () => {
     it('should return to explore with no country selected and placeholder visible', () => {
-      // Select a country first
+      vi.useFakeTimers();
+
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       rows[2].click();
       fixture.detectChanges();
 
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
-      btn.click(); // to show-all
+      btn.click();
       fixture.detectChanges();
-      btn.click(); // back to explore
+      vi.runAllTimers(); // flush modeAnnouncement clear from first toggle
+
+      btn.click();
       fixture.detectChanges();
+      vi.runAllTimers(); // flush modeAnnouncement clear from second toggle
 
       expect(component.selectedCountry()).toBeNull();
       expect(component.showAll()).toBe(false);
       const placeholder = el.querySelector('.placeholder');
       expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
+
+      vi.useRealTimers();
     });
   });
 

--- a/src/app/features/countries/countries.component.edge.spec.ts
+++ b/src/app/features/countries/countries.component.edge.spec.ts
@@ -1,0 +1,334 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CountriesComponent } from './countries.component';
+import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
+
+describe('CountriesComponent — edge cases & failure modes', () => {
+  let fixture: ComponentFixture<CountriesComponent>;
+  let component: CountriesComponent;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CountriesComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CountriesComponent);
+    component = fixture.componentInstance;
+    el = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  // ===== Data model exclusions =====
+  describe('data model', () => {
+    it('should not include French Guiana', () => {
+      const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name.toLowerCase());
+      expect(names).not.toContain('guayana francesa');
+      expect(names).not.toContain('french guiana');
+      expect(names).not.toContain('guyane');
+    });
+
+    it('should use Sucre as Bolivia capital', () => {
+      const bolivia = SOUTH_AMERICAN_COUNTRIES.find((c) => c.name === 'Bolivia');
+      expect(bolivia?.capital).toBe('Sucre');
+    });
+
+    it('should contain all expected countries', () => {
+      const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name);
+      const expected = [
+        'Argentina', 'Bolivia', 'Brasil', 'Chile', 'Colombia',
+        'Ecuador', 'Guyana', 'Paraguay', 'Perú', 'Surinam',
+        'Uruguay', 'Venezuela',
+      ];
+      expect(names).toEqual(expected);
+    });
+  });
+
+  // ===== selectCountry is no-op in show-all mode =====
+  describe('selectCountry in show-all mode', () => {
+    it('should not select a country when showAll is true', () => {
+      component.showAll.set(true);
+      fixture.detectChanges();
+
+      component.selectCountry('Argentina');
+      expect(component.selectedCountry()).toBeNull();
+    });
+  });
+
+  // ===== Capital wrapper always in DOM =====
+  describe('capital wrapper DOM presence', () => {
+    it('should have capital wrappers for all 12 countries in explore mode', () => {
+      const wrappers = el.querySelectorAll('.capital-wrapper');
+      expect(wrappers.length).toBe(12);
+    });
+
+    it('should have aria-hidden="true" on all capital wrappers initially', () => {
+      const wrappers = el.querySelectorAll('.capital-wrapper');
+      wrappers.forEach((w) => {
+        expect(w.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
+
+    it('should set aria-hidden="false" only on the selected capital wrapper', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[3].click(); // Chile
+      fixture.detectChanges();
+
+      const wrappers = el.querySelectorAll('.capital-wrapper');
+      wrappers.forEach((w, i) => {
+        expect(w.getAttribute('aria-hidden')).toBe(i === 3 ? 'false' : 'true');
+      });
+    });
+
+    it('should add .open class only to the selected capital wrapper', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[5].click(); // Ecuador
+      fixture.detectChanges();
+
+      const wrappers = el.querySelectorAll('.capital-wrapper');
+      wrappers.forEach((w, i) => {
+        expect(w.classList.contains('open')).toBe(i === 5);
+      });
+    });
+  });
+
+  // ===== Roving tabindex =====
+  describe('roving tabindex', () => {
+    it('should set tabindex=0 on first row and -1 on others initially', () => {
+      const rows = el.querySelectorAll('.country-row');
+      rows.forEach((row, i) => {
+        expect(row.getAttribute('tabindex')).toBe(i === 0 ? '0' : '-1');
+      });
+    });
+
+    it('should update tabindex when focusedIndex changes via ArrowDown', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(rows[0].getAttribute('tabindex')).toBe('-1');
+      expect(rows[1].getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  // ===== Checkmark on selection =====
+  describe('checkmark indicator', () => {
+    it('should show checkmark on selected row only', () => {
+      // Verify no row has a checkmark before selection
+      const rowsBefore = el.querySelectorAll('.country-row');
+      rowsBefore.forEach((row) => {
+        expect(row.querySelector('.country-row__check')).toBeNull();
+      });
+
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+
+      // Verify only the selected row contains a checkmark
+      const updatedRows = el.querySelectorAll('.country-row');
+      updatedRows.forEach((row, i) => {
+        const check = row.querySelector('.country-row__check');
+        if (i === 0) {
+          expect(check).toBeTruthy();
+          expect(check?.textContent).toContain('✓');
+        } else {
+          expect(check).toBeNull();
+        }
+      });
+    });
+  });
+
+  // ===== Chevron rotation class =====
+  describe('chevron indicator', () => {
+    it('should add open class to chevron when country is selected', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+
+      const chevrons = el.querySelectorAll('.country-row__chevron');
+      expect(chevrons[0].classList.contains('country-row__chevron--open')).toBe(true);
+      expect(chevrons[1].classList.contains('country-row__chevron--open')).toBe(false);
+    });
+
+    it('should remove open class when deselected', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+      rows[0].click();
+      fixture.detectChanges();
+
+      const chevrons = el.querySelectorAll('.country-row__chevron');
+      expect(chevrons[0].classList.contains('country-row__chevron--open')).toBe(false);
+    });
+  });
+
+  // ===== Toggle button visual state class =====
+  describe('toggle button visual state', () => {
+    it('should not have show-all class in explore mode', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLElement;
+      expect(btn.classList.contains('toggle-btn--show-all')).toBe(false);
+    });
+
+    it('should have show-all class in show-all mode', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      expect(btn.classList.contains('toggle-btn--show-all')).toBe(true);
+    });
+  });
+
+  // ===== Mid-animation toggle to show-all =====
+  describe('mid-animation toggle to show-all', () => {
+    it('should clear selection and switch to table cleanly', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[4].click(); // Colombia
+      fixture.detectChanges(); // Ensure selection state is applied before toggling mid-animation
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
+      expect(component.showAll()).toBe(true);
+      expect(el.querySelector('table')).toBeTruthy();
+      expect(el.querySelector('.country-list')).toBeNull();
+    });
+  });
+
+  // ===== liveRegionText computed signal =====
+  describe('liveRegionText signal', () => {
+    it('should return empty string when no selection and no announcement', () => {
+      expect((component as any).liveRegionText()).toBe('');
+    });
+
+    it('should return capital text when a country is selected', () => {
+      component.selectCountry('Perú');
+      expect((component as any).liveRegionText()).toBe('Capital: Lima');
+    });
+
+    it('should prioritize modeAnnouncement over capital text', () => {
+      component.selectCountry('Chile');
+      component.modeAnnouncement.set('Mostrando todas las capitales');
+      expect((component as any).liveRegionText()).toBe('Mostrando todas las capitales');
+    });
+  });
+
+  // ===== Listbox semantics =====
+  describe('ARIA listbox semantics', () => {
+    it('should have role="listbox" on the list', () => {
+      const list = el.querySelector('ul');
+      expect(list?.getAttribute('role')).toBe('listbox');
+    });
+
+    it('should have role="option" on each row', () => {
+      const rows = el.querySelectorAll('.country-row');
+      rows.forEach((row) => {
+        expect(row.getAttribute('role')).toBe('option');
+      });
+    });
+
+    it('should have aria-selected="false" on unselected rows', () => {
+      const rows = el.querySelectorAll('.country-row');
+      rows.forEach((row) => {
+        expect(row.getAttribute('aria-selected')).toBe('false');
+      });
+    });
+
+    it('should have aria-expanded="false" on unselected rows', () => {
+      const rows = el.querySelectorAll('.country-row');
+      rows.forEach((row) => {
+        expect(row.getAttribute('aria-expanded')).toBe('false');
+      });
+    });
+  });
+
+  // ===== Persistent aria-live region =====
+  describe('persistent aria-live region', () => {
+    it('should always be in the DOM regardless of mode', () => {
+      expect(el.querySelector('[aria-live="polite"]')).toBeTruthy();
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      expect(el.querySelector('[aria-live="polite"]')).toBeTruthy();
+
+      btn.click();
+      fixture.detectChanges();
+      expect(el.querySelector('[aria-live="polite"]')).toBeTruthy();
+    });
+  });
+
+  // ===== Table has no interactive rows =====
+  describe('show-all table non-interactivity', () => {
+    it('should not have click handlers on table rows (selecting in show-all is no-op)', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      // Verify no country-row elements exist (table uses different markup)
+      expect(el.querySelectorAll('.country-row').length).toBe(0);
+
+      // Table rows exist
+      const tableRows = el.querySelectorAll('.capitals-table__row');
+      expect(tableRows.length).toBe(12);
+    });
+  });
+
+  // ===== Keyboard: unrecognized keys are ignored =====
+  describe('keyboard: unrecognized keys', () => {
+    it('should not change state on unrecognized key', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
+      expect(component.focusedIndex()).toBe(0);
+    });
+  });
+
+  // ===== Show-all table caption =====
+  describe('show-all table caption', () => {
+    it('should have sr-only caption', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      const caption = el.querySelector('caption.sr-only');
+      expect(caption).toBeTruthy();
+      expect(caption?.textContent).toContain('Países y capitales de Sudamérica');
+    });
+  });
+
+  // ===== Double toggle show-all restores explore with no pre-selection =====
+  describe('double toggle show-all', () => {
+    it('should return to explore with no country selected and placeholder visible', () => {
+      // Select a country first
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[2].click();
+      fixture.detectChanges();
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click(); // to show-all
+      fixture.detectChanges();
+      btn.click(); // back to explore
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
+      expect(component.showAll()).toBe(false);
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
+    });
+  });
+
+  // ===== Each capital text is correct =====
+  describe('capital text correctness', () => {
+    it('should display correct capital for each country', () => {
+      for (const country of SOUTH_AMERICAN_COUNTRIES) {
+        component.selectCountry(country.name);
+        fixture.detectChanges();
+
+        const liveRegion = el.querySelector('[aria-live="polite"]');
+        expect(liveRegion?.textContent).toContain(`Capital: ${country.capital}`);
+      }
+    });
+  });
+});

--- a/src/app/features/countries/countries.component.html
+++ b/src/app/features/countries/countries.component.html
@@ -2,6 +2,7 @@
   <div class="card-header">
     <h2>Capitales de Sudam&#233;rica</h2>
     <button
+      #toggleButton
       type="button"
       class="toggle-btn"
       [class.toggle-btn--show-all]="showAll()"
@@ -80,7 +81,7 @@
       <tbody>
         @for (country of countries; track country.name) {
           <tr class="capitals-table__row">
-            <td>{{ country.flag }} {{ country.name }}</td>
+            <td><span class="table-flag">{{ country.flag }}</span> {{ country.name }}</td>
             <td>{{ country.capital }}</td>
           </tr>
         }

--- a/src/app/features/countries/countries.component.html
+++ b/src/app/features/countries/countries.component.html
@@ -1,0 +1,90 @@
+<div class="card">
+  <div class="card-header">
+    <h2>Capitales de Sudam&#233;rica</h2>
+    <button
+      type="button"
+      class="toggle-btn"
+      [class.toggle-btn--show-all]="showAll()"
+      [attr.aria-expanded]="showAll()"
+      (click)="toggleShowAll()"
+    >
+      @if (showAll()) {
+        Explorar una por una
+      } @else {
+        Ver todas las capitales
+      }
+    </button>
+  </div>
+
+  <!-- Persistent aria-live region — never removed from DOM -->
+  <div aria-live="polite" class="sr-only">{{ liveRegionText() }}</div>
+
+  <!-- Placeholder text — always in DOM, toggled via CSS opacity -->
+  <p
+    class="placeholder"
+    [class.placeholder--hidden]="!showPlaceholder()"
+    [attr.aria-hidden]="!showPlaceholder()"
+  >
+    Selecciona un pa&#237;s para ver su capital
+  </p>
+
+  @if (!showAll()) {
+    <!-- Explore mode: interactive list -->
+    <ul role="listbox" class="country-list" aria-label="Pa&#237;ses de Sudam&#233;rica">
+      @for (country of countries; track country.name; let i = $index) {
+        <li
+          #countryRow
+          role="option"
+          class="country-row"
+          [class.country-row--selected]="isSelected(country.name)"
+          [attr.aria-selected]="isSelected(country.name)"
+          [attr.aria-expanded]="isSelected(country.name)"
+          [attr.tabindex]="focusedIndex() === i ? 0 : -1"
+          (click)="selectCountry(country.name)"
+          (keydown)="onCountryKeydown($event, i)"
+        >
+          <div class="country-row__content">
+            <span class="country-row__flag">{{ country.flag }}</span>
+            <span class="country-row__name">
+              @if (isSelected(country.name)) {
+                <span class="country-row__check" aria-hidden="true">&#10003;</span>
+              }
+              {{ country.name }}
+            </span>
+            <span class="country-row__chevron" aria-hidden="true" [class.country-row__chevron--open]="isSelected(country.name)">&#9656;</span>
+          </div>
+          <!-- Capital wrapper: always in DOM, toggled via .open CSS class for reliable transitions -->
+          <!-- grid-template-rows animation requires Chrome 107+, Firefox 66+, Safari 16.4+. Older browsers degrade to instant reveal. -->
+          <div
+            class="capital-wrapper"
+            [class.open]="isSelected(country.name)"
+            [attr.aria-hidden]="!isSelected(country.name)"
+          >
+            <div class="capital-wrapper__inner">
+              <span class="capital-text">{{ country.capital }}</span>
+            </div>
+          </div>
+        </li>
+      }
+    </ul>
+  } @else {
+    <!-- Show-all mode: semantic table -->
+    <table class="capitals-table">
+      <caption class="sr-only">Pa&#237;ses y capitales de Sudam&#233;rica</caption>
+      <thead>
+        <tr>
+          <th scope="col">Pa&#237;s</th>
+          <th scope="col">Capital</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (country of countries; track country.name) {
+          <tr class="capitals-table__row">
+            <td>{{ country.flag }} {{ country.name }}</td>
+            <td>{{ country.capital }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+</div>

--- a/src/app/features/countries/countries.component.spec.ts
+++ b/src/app/features/countries/countries.component.spec.ts
@@ -1,0 +1,361 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CountriesComponent } from './countries.component';
+import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
+
+describe('CountriesComponent', () => {
+  let fixture: ComponentFixture<CountriesComponent>;
+  let component: CountriesComponent;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CountriesComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CountriesComponent);
+    component = fixture.componentInstance;
+    el = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  // ===== Data integrity =====
+  describe('data integrity', () => {
+    it('should have exactly 12 countries', () => {
+      expect(SOUTH_AMERICAN_COUNTRIES.length).toBe(12);
+    });
+
+    it('should be sorted alphabetically by name', () => {
+      const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name);
+      const sorted = [...names].sort((a, b) => a.localeCompare(b, 'es'));
+      expect(names).toEqual(sorted);
+    });
+
+    it('should have no empty fields', () => {
+      for (const country of SOUTH_AMERICAN_COUNTRIES) {
+        expect(country.name.length).toBeGreaterThan(0);
+        expect(country.capital.length).toBeGreaterThan(0);
+        expect(country.flag.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // ===== Initial render =====
+  describe('initial render', () => {
+    it('should display all 12 countries', () => {
+      const rows = el.querySelectorAll('.country-row');
+      expect(rows.length).toBe(12);
+    });
+
+    it('should show the heading', () => {
+      const h2 = el.querySelector('h2');
+      expect(h2?.textContent).toContain('Capitales de Sudam\u00e9rica');
+    });
+
+    it('should show toggle button with correct label and aria-expanded', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      expect(btn.textContent?.trim()).toBe('Ver todas las capitales');
+      expect(btn.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should show placeholder text', () => {
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.textContent).toContain('Selecciona un pa\u00eds para ver su capital');
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('should display flag emojis', () => {
+      const flags = el.querySelectorAll('.country-row__flag');
+      expect(flags.length).toBe(12);
+      flags.forEach((flag) => {
+        expect(flag.textContent?.trim().length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should display chevron indicators', () => {
+      const chevrons = el.querySelectorAll('.country-row__chevron');
+      expect(chevrons.length).toBe(12);
+    });
+  });
+
+  // ===== Selection =====
+  describe('country selection', () => {
+    it('should reveal capital when a country is clicked', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBe('Argentina');
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Capital: Buenos Aires');
+    });
+
+    it('should hide placeholder when a country is selected', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.classList.contains('placeholder--hidden')).toBe(true);
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should highlight the selected row', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+
+      expect(row.classList.contains('country-row--selected')).toBe(true);
+      expect(row.getAttribute('aria-selected')).toBe('true');
+      expect(row.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  // ===== Toggle deselect =====
+  describe('toggle deselect', () => {
+    it('should collapse capital when same country is clicked again', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      row.click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent?.trim()).toBe('');
+    });
+
+    it('should restore placeholder on deselect', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      row.click();
+      fixture.detectChanges();
+
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.classList.contains('placeholder--hidden')).toBe(false);
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
+    });
+  });
+
+  // ===== Switch selection =====
+  describe('switch selection', () => {
+    it('should switch from one country to another', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+      rows[1].click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBe('Bolivia');
+      expect(rows[0].classList.contains('country-row--selected')).toBe(false);
+      expect(rows[1].classList.contains('country-row--selected')).toBe(true);
+
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Capital: Sucre');
+    });
+  });
+
+  // ===== Show all toggle =====
+  describe('show all toggle', () => {
+    it('should switch to table mode', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      expect(component.showAll()).toBe(true);
+      const table = el.querySelector('table');
+      expect(table).toBeTruthy();
+      const tableRows = el.querySelectorAll('.capitals-table__row');
+      expect(tableRows.length).toBe(12);
+    });
+
+    it('should have proper table semantics', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      const caption = el.querySelector('caption');
+      expect(caption?.textContent).toContain('Pa\u00edses y capitales de Sudam\u00e9rica');
+
+      const ths = el.querySelectorAll('th[scope="col"]');
+      expect(ths.length).toBe(2);
+    });
+
+    it('should update button label and aria-expanded', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      expect(btn.textContent?.trim()).toBe('Explorar una por una');
+      expect(btn.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('should display flag emojis in table mode', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      const firstRowText = el.querySelector('.capitals-table__row td')?.textContent;
+      // Should contain flag emoji for Argentina
+      expect(firstRowText).toContain('Argentina');
+    });
+
+    it('should clear selection when toggling to show-all', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
+    });
+
+    it('should announce mode switch', async () => {
+      vi.useFakeTimers();
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Mostrando todas las capitales');
+
+      vi.runAllTimers();
+      fixture.detectChanges();
+      // After tick, announcement should clear
+      expect(liveRegion?.textContent?.trim()).toBe('');
+      vi.useRealTimers();
+    });
+  });
+
+  // ===== Return to explore =====
+  describe('return to explore mode', () => {
+    it('should return to list view', () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      btn.click();
+      fixture.detectChanges();
+
+      expect(component.showAll()).toBe(false);
+      const list = el.querySelector('.country-list');
+      expect(list).toBeTruthy();
+      expect(el.querySelector('table')).toBeNull();
+    });
+
+    it('should announce return to explore mode', async () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      btn.click();
+      fixture.detectChanges();
+
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toContain('Modo exploraci\u00f3n');
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      fixture.detectChanges();
+      expect(liveRegion?.textContent?.trim()).toBe('');
+    });
+  });
+
+  // ===== Keyboard navigation =====
+  describe('keyboard navigation', () => {
+    it('should select country on Enter', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+      row.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBe('Argentina');
+    });
+
+    it('should select country on Space and call preventDefault', () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      const event = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        cancelable: true,
+      });
+      const spy = vi.spyOn(event, 'preventDefault');
+      row.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalled();
+      expect(component.selectedCountry()).toBe('Argentina');
+    });
+
+    it('should move focusedIndex on ArrowDown (clamped)', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+
+      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      rows[0].dispatchEvent(downEvent);
+      fixture.detectChanges();
+
+      expect(component.focusedIndex()).toBe(1);
+    });
+
+    it('should clamp focusedIndex at boundaries', () => {
+      // Set to last index
+      component.focusedIndex.set(11);
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      rows[11].dispatchEvent(downEvent);
+      fixture.detectChanges();
+
+      expect(component.focusedIndex()).toBe(11);
+
+      // Test upper boundary
+      component.focusedIndex.set(0);
+      fixture.detectChanges();
+      const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      rows[0].dispatchEvent(upEvent);
+      fixture.detectChanges();
+
+      expect(component.focusedIndex()).toBe(0);
+    });
+  });
+
+  // ===== aria-live safety =====
+  describe('aria-live safety', () => {
+    it('should never contain "Capital: undefined" or "Capital: null"', () => {
+      // Initially no selection
+      const liveRegion = el.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).not.toContain('Capital: undefined');
+      expect(liveRegion?.textContent).not.toContain('Capital: null');
+      expect(liveRegion?.textContent?.trim()).toBe('');
+
+      // Select and deselect
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      row.click();
+      fixture.detectChanges();
+
+      expect(liveRegion?.textContent).not.toContain('Capital: undefined');
+      expect(liveRegion?.textContent).not.toContain('Capital: null');
+      expect(liveRegion?.textContent?.trim()).toBe('');
+    });
+  });
+
+  // ===== Rapid clicks =====
+  describe('rapid sequential clicks', () => {
+    it('should resolve to the last selection', () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      rows[1].click();
+      rows[2].click();
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBe('Brasil');
+      expect(rows[0].classList.contains('country-row--selected')).toBe(false);
+      expect(rows[1].classList.contains('country-row--selected')).toBe(false);
+      expect(rows[2].classList.contains('country-row--selected')).toBe(true);
+    });
+  });
+});

--- a/src/app/features/countries/countries.component.spec.ts
+++ b/src/app/features/countries/countries.component.spec.ts
@@ -28,7 +28,7 @@ describe('CountriesComponent', () => {
       expect(SOUTH_AMERICAN_COUNTRIES.length).toBe(12);
     });
 
-    it('should be sorted alphabetically by name', () => {
+    it('should be sorted alphabetically by name (Spanish locale)', () => {
       const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name);
       const sorted = [...names].sort((a, b) => a.localeCompare(b, 'es'));
       expect(names).toEqual(sorted);
@@ -41,6 +41,27 @@ describe('CountriesComponent', () => {
         expect(country.flag.length).toBeGreaterThan(0);
       }
     });
+
+    it('should not include French Guiana', () => {
+      const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name.toLowerCase());
+      expect(names).not.toContain('guayana francesa');
+      expect(names).not.toContain('french guiana');
+    });
+
+    it('should contain expected countries', () => {
+      const names = SOUTH_AMERICAN_COUNTRIES.map((c) => c.name);
+      const expected = [
+        'Argentina', 'Bolivia', 'Brasil', 'Chile', 'Colombia',
+        'Ecuador', 'Guyana', 'Paraguay', 'Perú', 'Surinam',
+        'Uruguay', 'Venezuela',
+      ];
+      expect(names).toEqual(expected);
+    });
+
+    it('should map Bolivia capital to Sucre', () => {
+      const bolivia = SOUTH_AMERICAN_COUNTRIES.find((c) => c.name === 'Bolivia');
+      expect(bolivia?.capital).toBe('Sucre');
+    });
   });
 
   // ===== Initial render =====
@@ -48,6 +69,13 @@ describe('CountriesComponent', () => {
     it('should display all 12 countries', () => {
       const rows = el.querySelectorAll('.country-row');
       expect(rows.length).toBe(12);
+    });
+
+    it('should render countries inside a listbox', () => {
+      const listbox = el.querySelector('[role="listbox"]');
+      expect(listbox).toBeTruthy();
+      const options = listbox!.querySelectorAll('[role="option"]');
+      expect(options.length).toBe(12);
     });
 
     it('should show the heading', () => {
@@ -61,13 +89,13 @@ describe('CountriesComponent', () => {
       expect(btn.getAttribute('aria-expanded')).toBe('false');
     });
 
-    it('should show placeholder text', () => {
+    it('should show placeholder text with aria-hidden="false"', () => {
       const placeholder = el.querySelector('.placeholder');
       expect(placeholder?.textContent).toContain('Selecciona un país para ver su capital');
       expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
     });
 
-    it('should display flag emojis', () => {
+    it('should display flag emojis in fixed-width containers', () => {
       const flags = el.querySelectorAll('.country-row__flag');
       expect(flags.length).toBe(12);
       flags.forEach((flag) => {
@@ -78,10 +106,31 @@ describe('CountriesComponent', () => {
     it('should display chevron indicators', () => {
       const chevrons = el.querySelectorAll('.country-row__chevron');
       expect(chevrons.length).toBe(12);
+      chevrons.forEach((ch) => {
+        expect(ch.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
+
+    it('should have roving tabindex with first item at 0', () => {
+      const rows = el.querySelectorAll('.country-row');
+      expect(rows[0].getAttribute('tabindex')).toBe('0');
+      expect(rows[1].getAttribute('tabindex')).toBe('-1');
+      expect(rows[11].getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should have aria-live region in DOM', () => {
+      const live = el.querySelector('[aria-live="polite"]');
+      expect(live).toBeTruthy();
+      expect(live!.textContent?.trim()).toBe('');
+    });
+
+    it('should not have toggle-btn--show-all class initially', () => {
+      const btn = el.querySelector('.toggle-btn');
+      expect(btn?.classList.contains('toggle-btn--show-all')).toBe(false);
     });
   });
 
-  // ===== Selection =====
+  // ===== Country selection =====
   describe('country selection', () => {
     it('should reveal capital when a country is clicked', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
@@ -105,7 +154,7 @@ describe('CountriesComponent', () => {
       expect(placeholder?.getAttribute('aria-hidden')).toBe('true');
     });
 
-    it('should highlight the selected row', async () => {
+    it('should highlight the selected row with aria attributes', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
@@ -114,6 +163,49 @@ describe('CountriesComponent', () => {
       expect(row.classList.contains('country-row--selected')).toBe(true);
       expect(row.getAttribute('aria-selected')).toBe('true');
       expect(row.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('should add open class to capital wrapper of selected row', async () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const wrapper = row.querySelector('.capital-wrapper');
+      expect(wrapper?.classList.contains('open')).toBe(true);
+      expect(wrapper?.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('should rotate chevron on selected row', async () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const chevron = row.querySelector('.country-row__chevron');
+      expect(chevron?.classList.contains('country-row__chevron--open')).toBe(true);
+    });
+
+    it('should show checkmark on selected row', async () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const check = row.querySelector('.country-row__check');
+      expect(check).toBeTruthy();
+      expect(check?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should not select rows that are not clicked', async () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(rows[1].classList.contains('country-row--selected')).toBe(false);
+      expect(rows[1].getAttribute('aria-selected')).toBe('false');
+      expect(rows[1].getAttribute('aria-expanded')).toBe('false');
     });
   });
 
@@ -146,11 +238,25 @@ describe('CountriesComponent', () => {
       expect(placeholder?.classList.contains('placeholder--hidden')).toBe(false);
       expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
     });
+
+    it('should remove selection styling on deselect', async () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      row.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      row.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(row.classList.contains('country-row--selected')).toBe(false);
+      expect(row.getAttribute('aria-selected')).toBe('false');
+      expect(row.getAttribute('aria-expanded')).toBe('false');
+    });
   });
 
   // ===== Switch selection =====
   describe('switch selection', () => {
-    it('should switch from one country to another', async () => {
+    it('should switch from one country to another in single update', async () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       rows[0].click();
       fixture.detectChanges();
@@ -166,11 +272,23 @@ describe('CountriesComponent', () => {
       const liveRegion = el.querySelector('[aria-live="polite"]');
       expect(liveRegion?.textContent).toContain('Capital: Sucre');
     });
+
+    it('should only have one selected row after switching', async () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+      rows[3].click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const selected = el.querySelectorAll('.country-row--selected');
+      expect(selected.length).toBe(1);
+    });
   });
 
   // ===== Show all toggle =====
   describe('show all toggle', () => {
-    it('should switch to table mode', async () => {
+    it('should switch to table mode with 12 rows', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
@@ -189,14 +307,12 @@ describe('CountriesComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      const caption = el.querySelector('caption');
-      expect(caption?.textContent).toContain('Países y capitales de Sudamérica');
-
-      const ths = el.querySelectorAll('th[scope="col"]');
-      expect(ths.length).toBe(2);
+      expect(el.querySelector('caption')?.textContent).toContain('Países y capitales de Sudamérica');
+      expect(el.querySelector('thead')).toBeTruthy();
+      expect(el.querySelectorAll('th[scope="col"]').length).toBe(2);
     });
 
-    it('should update button label and aria-expanded', async () => {
+    it('should update button label, aria-expanded, and visual class', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
@@ -204,6 +320,7 @@ describe('CountriesComponent', () => {
 
       expect(btn.textContent?.trim()).toBe('Explorar una por una');
       expect(btn.getAttribute('aria-expanded')).toBe('true');
+      expect(btn.classList.contains('toggle-btn--show-all')).toBe(true);
     });
 
     it('should display flag emojis in table mode', async () => {
@@ -212,8 +329,8 @@ describe('CountriesComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      const firstRowText = el.querySelector('.capitals-table__row td')?.textContent;
-      expect(firstRowText).toContain('Argentina');
+      const flags = el.querySelectorAll('.table-flag');
+      expect(flags.length).toBe(12);
     });
 
     it('should clear selection when toggling to show-all', async () => {
@@ -230,7 +347,28 @@ describe('CountriesComponent', () => {
       expect(component.selectedCountry()).toBeNull();
     });
 
-    it('should announce mode switch', async () => {
+    it('should hide placeholder in show-all mode', async () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('true');
+      expect(placeholder?.classList.contains('placeholder--hidden')).toBe(true);
+    });
+
+    it('should remove interactive list in show-all mode', async () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(el.querySelector('[role="listbox"]')).toBeNull();
+      expect(el.querySelectorAll('.country-row').length).toBe(0);
+    });
+
+    it('should announce mode switch then clear', async () => {
       vi.useFakeTimers();
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
@@ -244,11 +382,21 @@ describe('CountriesComponent', () => {
       expect(liveRegion?.textContent?.trim()).toBe('');
       vi.useRealTimers();
     });
+
+    it('should not allow selection in show-all mode', async () => {
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component.selectCountry('Argentina');
+      expect(component.selectedCountry()).toBeNull();
+    });
   });
 
-  // ===== Return to explore =====
+  // ===== Return to explore mode =====
   describe('return to explore mode', () => {
-    it('should return to list view', async () => {
+    it('should return to list view with no selection', async () => {
       vi.useFakeTimers();
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
@@ -259,13 +407,14 @@ describe('CountriesComponent', () => {
       vi.runAllTimers();
 
       expect(component.showAll()).toBe(false);
+      expect(component.selectedCountry()).toBeNull();
       const list = el.querySelector('.country-list');
       expect(list).toBeTruthy();
       expect(el.querySelector('table')).toBeNull();
       vi.useRealTimers();
     });
 
-    it('should announce return to explore mode', async () => {
+    it('should announce "Modo exploración" then clear', async () => {
       vi.useFakeTimers();
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
@@ -281,6 +430,37 @@ describe('CountriesComponent', () => {
       vi.runAllTimers();
       fixture.detectChanges();
       expect(liveRegion?.textContent?.trim()).toBe('');
+      vi.useRealTimers();
+    });
+
+    it('should restore toggle button to explore state', async () => {
+      vi.useFakeTimers();
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+
+      expect(btn.textContent?.trim()).toBe('Ver todas las capitales');
+      expect(btn.getAttribute('aria-expanded')).toBe('false');
+      expect(btn.classList.contains('toggle-btn--show-all')).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it('should show placeholder again after returning to explore mode', async () => {
+      vi.useFakeTimers();
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+
+      const placeholder = el.querySelector('.placeholder');
+      expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
       vi.useRealTimers();
     });
   });
@@ -313,38 +493,76 @@ describe('CountriesComponent', () => {
       expect(component.selectedCountry()).toBe('Argentina');
     });
 
-    it('should move focusedIndex on ArrowDown (clamped)', async () => {
+    it('should move focusedIndex down on ArrowDown', async () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
-
-      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
-      rows[0].dispatchEvent(downEvent);
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      rows[0].dispatchEvent(event);
       fixture.detectChanges();
       await fixture.whenStable();
 
       expect(component.focusedIndex()).toBe(1);
     });
 
-    it('should clamp focusedIndex at boundaries', async () => {
+    it('should clamp focusedIndex at last item on ArrowDown', async () => {
       component.focusedIndex.set(11);
       fixture.detectChanges();
       await fixture.whenStable();
 
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
-      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
-      rows[11].dispatchEvent(downEvent);
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      rows[11].dispatchEvent(event);
       fixture.detectChanges();
       await fixture.whenStable();
 
       expect(component.focusedIndex()).toBe(11);
+    });
 
+    it('should clamp focusedIndex at 0 on ArrowUp', async () => {
       component.focusedIndex.set(0);
       fixture.detectChanges();
       await fixture.whenStable();
-      const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
-      rows[0].dispatchEvent(upEvent);
+
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      rows[0].dispatchEvent(event);
       fixture.detectChanges();
       await fixture.whenStable();
 
+      expect(component.focusedIndex()).toBe(0);
+    });
+
+    it('should move focusedIndex up on ArrowUp', async () => {
+      component.focusedIndex.set(5);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      rows[5].dispatchEvent(event);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.focusedIndex()).toBe(4);
+    });
+
+    it('should update tabindex attributes after focus change', async () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      rows[0].dispatchEvent(event);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(rows[0].getAttribute('tabindex')).toBe('-1');
+      expect(rows[1].getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should not respond to unrelated keys', async () => {
+      const row = el.querySelector('.country-row') as HTMLElement;
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
+      row.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(component.selectedCountry()).toBeNull();
       expect(component.focusedIndex()).toBe(0);
     });
   });
@@ -353,21 +571,70 @@ describe('CountriesComponent', () => {
   describe('aria-live safety', () => {
     it('should never contain "Capital: undefined" or "Capital: null"', async () => {
       const liveRegion = el.querySelector('[aria-live="polite"]');
-      expect(liveRegion?.textContent).not.toContain('Capital: undefined');
-      expect(liveRegion?.textContent).not.toContain('Capital: null');
+      expect(liveRegion?.textContent).not.toContain('undefined');
+      expect(liveRegion?.textContent).not.toContain('null');
       expect(liveRegion?.textContent?.trim()).toBe('');
 
+      // Select and deselect
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
       await fixture.whenStable();
+
+      expect(liveRegion?.textContent).not.toContain('undefined');
+      expect(liveRegion?.textContent).not.toContain('null');
+
       row.click();
       fixture.detectChanges();
       await fixture.whenStable();
 
-      expect(liveRegion?.textContent).not.toContain('Capital: undefined');
-      expect(liveRegion?.textContent).not.toContain('Capital: null');
+      expect(liveRegion?.textContent).not.toContain('undefined');
+      expect(liveRegion?.textContent).not.toContain('null');
       expect(liveRegion?.textContent?.trim()).toBe('');
+    });
+
+    it('should persist aria-live region across mode switches', async () => {
+      vi.useFakeTimers();
+      const liveBefore = el.querySelector('[aria-live="polite"]');
+      expect(liveBefore).toBeTruthy();
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+
+      const liveShowAll = el.querySelector('[aria-live="polite"]');
+      expect(liveShowAll).toBeTruthy();
+
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+
+      const liveExplore = el.querySelector('[aria-live="polite"]');
+      expect(liveExplore).toBeTruthy();
+      vi.useRealTimers();
+    });
+
+    it('should return correct capital for each country', () => {
+      const expectedPairs: [string, string][] = [
+        ['Argentina', 'Capital: Buenos Aires'],
+        ['Bolivia', 'Capital: Sucre'],
+        ['Brasil', 'Capital: Brasilia'],
+        ['Chile', 'Capital: Santiago'],
+        ['Colombia', 'Capital: Bogotá'],
+        ['Ecuador', 'Capital: Quito'],
+        ['Guyana', 'Capital: Georgetown'],
+        ['Paraguay', 'Capital: Asunción'],
+        ['Perú', 'Capital: Lima'],
+        ['Surinam', 'Capital: Paramaribo'],
+        ['Uruguay', 'Capital: Montevideo'],
+        ['Venezuela', 'Capital: Caracas'],
+      ];
+
+      for (const [name, expected] of expectedPairs) {
+        component.selectCountry(name);
+        expect(component['announcementText']()).toBe(expected);
+      }
     });
   });
 
@@ -385,6 +652,75 @@ describe('CountriesComponent', () => {
       expect(rows[0].classList.contains('country-row--selected')).toBe(false);
       expect(rows[1].classList.contains('country-row--selected')).toBe(false);
       expect(rows[2].classList.contains('country-row--selected')).toBe(true);
+    });
+
+    it('should handle rapid select-deselect-select', async () => {
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click(); // select Argentina
+      rows[0].click(); // deselect Argentina
+      rows[1].click(); // select Bolivia
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.selectedCountry()).toBe('Bolivia');
+    });
+
+    it('should cleanly switch to show-all mid-selection', async () => {
+      vi.useFakeTimers();
+      const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
+      rows[0].click();
+      fixture.detectChanges();
+
+      const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+      vi.runAllTimers();
+      fixture.detectChanges();
+
+      expect(component.showAll()).toBe(true);
+      expect(component.selectedCountry()).toBeNull();
+      const table = el.querySelector('table');
+      expect(table).toBeTruthy();
+      // No ghost expanded rows
+      expect(el.querySelectorAll('.country-row--selected').length).toBe(0);
+      vi.useRealTimers();
+    });
+  });
+
+  // ===== Component signal state =====
+  describe('signal state management', () => {
+    it('showPlaceholder should be true initially', () => {
+      expect(component['showPlaceholder']()).toBe(true);
+    });
+
+    it('showPlaceholder should be false when selected', () => {
+      component.selectCountry('Chile');
+      expect(component['showPlaceholder']()).toBe(false);
+    });
+
+    it('showPlaceholder should be false in show-all mode', () => {
+      component.toggleShowAll();
+      expect(component['showPlaceholder']()).toBe(false);
+    });
+
+    it('showPlaceholder should return to true after deselecting', () => {
+      component.selectCountry('Chile');
+      component.selectCountry('Chile');
+      expect(component['showPlaceholder']()).toBe(true);
+    });
+
+    it('liveRegionText should prioritize modeAnnouncement over announcementText', () => {
+      component.selectCountry('Argentina');
+      expect(component['liveRegionText']()).toBe('Capital: Buenos Aires');
+
+      // Simulate mode announcement taking priority
+      component.modeAnnouncement.set('Mostrando todas las capitales');
+      expect(component['liveRegionText']()).toBe('Mostrando todas las capitales');
+    });
+
+    it('announcementText should return empty string for unknown country', () => {
+      component.selectedCountry.set('NonExistent');
+      expect(component['announcementText']()).toBe('');
     });
   });
 });

--- a/src/app/features/countries/countries.component.spec.ts
+++ b/src/app/features/countries/countries.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { CountriesComponent } from './countries.component';
 import { SOUTH_AMERICAN_COUNTRIES } from './country.model';
 
 describe('CountriesComponent', () => {
+  setupTestBed();
+
   let fixture: ComponentFixture<CountriesComponent>;
   let component: CountriesComponent;
   let el: HTMLElement;
@@ -16,6 +19,7 @@ describe('CountriesComponent', () => {
     component = fixture.componentInstance;
     el = fixture.nativeElement;
     fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   // ===== Data integrity =====
@@ -48,7 +52,7 @@ describe('CountriesComponent', () => {
 
     it('should show the heading', () => {
       const h2 = el.querySelector('h2');
-      expect(h2?.textContent).toContain('Capitales de Sudam\u00e9rica');
+      expect(h2?.textContent).toContain('Capitales de Sudamérica');
     });
 
     it('should show toggle button with correct label and aria-expanded', () => {
@@ -59,7 +63,7 @@ describe('CountriesComponent', () => {
 
     it('should show placeholder text', () => {
       const placeholder = el.querySelector('.placeholder');
-      expect(placeholder?.textContent).toContain('Selecciona un pa\u00eds para ver su capital');
+      expect(placeholder?.textContent).toContain('Selecciona un país para ver su capital');
       expect(placeholder?.getAttribute('aria-hidden')).toBe('false');
     });
 
@@ -79,30 +83,33 @@ describe('CountriesComponent', () => {
 
   // ===== Selection =====
   describe('country selection', () => {
-    it('should reveal capital when a country is clicked', () => {
+    it('should reveal capital when a country is clicked', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBe('Argentina');
       const liveRegion = el.querySelector('[aria-live="polite"]');
       expect(liveRegion?.textContent).toContain('Capital: Buenos Aires');
     });
 
-    it('should hide placeholder when a country is selected', () => {
+    it('should hide placeholder when a country is selected', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const placeholder = el.querySelector('.placeholder');
       expect(placeholder?.classList.contains('placeholder--hidden')).toBe(true);
       expect(placeholder?.getAttribute('aria-hidden')).toBe('true');
     });
 
-    it('should highlight the selected row', () => {
+    it('should highlight the selected row', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(row.classList.contains('country-row--selected')).toBe(true);
       expect(row.getAttribute('aria-selected')).toBe('true');
@@ -112,24 +119,28 @@ describe('CountriesComponent', () => {
 
   // ===== Toggle deselect =====
   describe('toggle deselect', () => {
-    it('should collapse capital when same country is clicked again', () => {
+    it('should collapse capital when same country is clicked again', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBeNull();
       const liveRegion = el.querySelector('[aria-live="polite"]');
       expect(liveRegion?.textContent?.trim()).toBe('');
     });
 
-    it('should restore placeholder on deselect', () => {
+    it('should restore placeholder on deselect', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const placeholder = el.querySelector('.placeholder');
       expect(placeholder?.classList.contains('placeholder--hidden')).toBe(false);
@@ -139,12 +150,14 @@ describe('CountriesComponent', () => {
 
   // ===== Switch selection =====
   describe('switch selection', () => {
-    it('should switch from one country to another', () => {
+    it('should switch from one country to another', async () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       rows[0].click();
       fixture.detectChanges();
+      await fixture.whenStable();
       rows[1].click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBe('Bolivia');
       expect(rows[0].classList.contains('country-row--selected')).toBe(false);
@@ -157,10 +170,11 @@ describe('CountriesComponent', () => {
 
   // ===== Show all toggle =====
   describe('show all toggle', () => {
-    it('should switch to table mode', () => {
+    it('should switch to table mode', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.showAll()).toBe(true);
       const table = el.querySelector('table');
@@ -169,45 +183,49 @@ describe('CountriesComponent', () => {
       expect(tableRows.length).toBe(12);
     });
 
-    it('should have proper table semantics', () => {
+    it('should have proper table semantics', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const caption = el.querySelector('caption');
-      expect(caption?.textContent).toContain('Pa\u00edses y capitales de Sudam\u00e9rica');
+      expect(caption?.textContent).toContain('Países y capitales de Sudamérica');
 
       const ths = el.querySelectorAll('th[scope="col"]');
       expect(ths.length).toBe(2);
     });
 
-    it('should update button label and aria-expanded', () => {
+    it('should update button label and aria-expanded', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(btn.textContent?.trim()).toBe('Explorar una por una');
       expect(btn.getAttribute('aria-expanded')).toBe('true');
     });
 
-    it('should display flag emojis in table mode', () => {
+    it('should display flag emojis in table mode', async () => {
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const firstRowText = el.querySelector('.capitals-table__row td')?.textContent;
-      // Should contain flag emoji for Argentina
       expect(firstRowText).toContain('Argentina');
     });
 
-    it('should clear selection when toggling to show-all', () => {
+    it('should clear selection when toggling to show-all', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBeNull();
     });
@@ -223,7 +241,6 @@ describe('CountriesComponent', () => {
 
       vi.runAllTimers();
       fixture.detectChanges();
-      // After tick, announcement should clear
       expect(liveRegion?.textContent?.trim()).toBe('');
       vi.useRealTimers();
     });
@@ -231,49 +248,56 @@ describe('CountriesComponent', () => {
 
   // ===== Return to explore =====
   describe('return to explore mode', () => {
-    it('should return to list view', () => {
+    it('should return to list view', async () => {
+      vi.useFakeTimers();
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
+      vi.runAllTimers();
       btn.click();
       fixture.detectChanges();
+      vi.runAllTimers();
 
       expect(component.showAll()).toBe(false);
       const list = el.querySelector('.country-list');
       expect(list).toBeTruthy();
       expect(el.querySelector('table')).toBeNull();
+      vi.useRealTimers();
     });
 
     it('should announce return to explore mode', async () => {
+      vi.useFakeTimers();
       const btn = el.querySelector('.toggle-btn') as HTMLButtonElement;
       btn.click();
       fixture.detectChanges();
-      await new Promise(resolve => setTimeout(resolve, 0));
+      vi.runAllTimers();
 
       btn.click();
       fixture.detectChanges();
 
       const liveRegion = el.querySelector('[aria-live="polite"]');
-      expect(liveRegion?.textContent).toContain('Modo exploraci\u00f3n');
+      expect(liveRegion?.textContent).toContain('Modo exploración');
 
-      await new Promise(resolve => setTimeout(resolve, 0));
+      vi.runAllTimers();
       fixture.detectChanges();
       expect(liveRegion?.textContent?.trim()).toBe('');
+      vi.useRealTimers();
     });
   });
 
   // ===== Keyboard navigation =====
   describe('keyboard navigation', () => {
-    it('should select country on Enter', () => {
+    it('should select country on Enter', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
       row.dispatchEvent(event);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBe('Argentina');
     });
 
-    it('should select country on Space and call preventDefault', () => {
+    it('should select country on Space and call preventDefault', async () => {
       const row = el.querySelector('.country-row') as HTMLElement;
       const event = new KeyboardEvent('keydown', {
         key: ' ',
@@ -283,39 +307,43 @@ describe('CountriesComponent', () => {
       const spy = vi.spyOn(event, 'preventDefault');
       row.dispatchEvent(event);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(spy).toHaveBeenCalled();
       expect(component.selectedCountry()).toBe('Argentina');
     });
 
-    it('should move focusedIndex on ArrowDown (clamped)', () => {
+    it('should move focusedIndex on ArrowDown (clamped)', async () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
 
       const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
       rows[0].dispatchEvent(downEvent);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.focusedIndex()).toBe(1);
     });
 
-    it('should clamp focusedIndex at boundaries', () => {
-      // Set to last index
+    it('should clamp focusedIndex at boundaries', async () => {
       component.focusedIndex.set(11);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
       rows[11].dispatchEvent(downEvent);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.focusedIndex()).toBe(11);
 
-      // Test upper boundary
       component.focusedIndex.set(0);
       fixture.detectChanges();
+      await fixture.whenStable();
       const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
       rows[0].dispatchEvent(upEvent);
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.focusedIndex()).toBe(0);
     });
@@ -323,19 +351,19 @@ describe('CountriesComponent', () => {
 
   // ===== aria-live safety =====
   describe('aria-live safety', () => {
-    it('should never contain "Capital: undefined" or "Capital: null"', () => {
-      // Initially no selection
+    it('should never contain "Capital: undefined" or "Capital: null"', async () => {
       const liveRegion = el.querySelector('[aria-live="polite"]');
       expect(liveRegion?.textContent).not.toContain('Capital: undefined');
       expect(liveRegion?.textContent).not.toContain('Capital: null');
       expect(liveRegion?.textContent?.trim()).toBe('');
 
-      // Select and deselect
       const row = el.querySelector('.country-row') as HTMLElement;
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
       row.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(liveRegion?.textContent).not.toContain('Capital: undefined');
       expect(liveRegion?.textContent).not.toContain('Capital: null');
@@ -345,12 +373,13 @@ describe('CountriesComponent', () => {
 
   // ===== Rapid clicks =====
   describe('rapid sequential clicks', () => {
-    it('should resolve to the last selection', () => {
+    it('should resolve to the last selection', async () => {
       const rows = el.querySelectorAll('.country-row') as NodeListOf<HTMLElement>;
       rows[0].click();
       rows[1].click();
       rows[2].click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(component.selectedCountry()).toBe('Brasil');
       expect(rows[0].classList.contains('country-row--selected')).toBe(false);

--- a/src/app/features/countries/countries.component.ts
+++ b/src/app/features/countries/countries.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   computed,
   signal,
+  viewChild,
   viewChildren,
   ElementRef,
   AfterViewInit,
@@ -28,6 +29,9 @@ export class CountriesComponent implements AfterViewInit {
 
   /** Transient mode-switch announcement, cleared after a tick. */
   readonly modeAnnouncement = signal('');
+
+  /** Toggle button ref for focus management after mode switch. */
+  readonly toggleButtonRef = viewChild<ElementRef<HTMLElement>>('toggleButton');
 
   /** Row element refs for programmatic focus management. */
   readonly countryRows = viewChildren<ElementRef<HTMLElement>>('countryRow');
@@ -96,6 +100,17 @@ export class CountriesComponent implements AfterViewInit {
 
     // Clear after a tick so screen readers pick it up
     setTimeout(() => this.modeAnnouncement.set(''), 0);
+
+    // After switching back to explore mode, ensure focus lands on toggle button
+    // (DOM swap via @if can cause focus to fall to <body>)
+    if (!newShowAll) {
+      setTimeout(() => {
+        const btn = this.toggleButtonRef();
+        if (btn) {
+          btn.nativeElement.focus();
+        }
+      }, 0);
+    }
 
     // TODO: emit analytics event — show_all_toggled { mode: string, previous_mode: string }
     void previousMode; // used for future analytics

--- a/src/app/features/countries/countries.component.ts
+++ b/src/app/features/countries/countries.component.ts
@@ -1,0 +1,150 @@
+import {
+  Component,
+  computed,
+  signal,
+  viewChildren,
+  ElementRef,
+  AfterViewInit,
+} from '@angular/core';
+import { SOUTH_AMERICAN_COUNTRIES, Country } from './country.model';
+
+@Component({
+  selector: 'app-countries',
+  standalone: true,
+  templateUrl: './countries.component.html',
+  styleUrl: './countries.component.css',
+})
+export class CountriesComponent implements AfterViewInit {
+  protected readonly countries = SOUTH_AMERICAN_COUNTRIES;
+
+  /** Currently selected country name, or null if none selected. */
+  readonly selectedCountry = signal<string | null>(null);
+
+  /** Whether we're in show-all table mode. */
+  readonly showAll = signal(false);
+
+  /** Index of the currently focused row for roving tabindex. */
+  readonly focusedIndex = signal(0);
+
+  /** Transient mode-switch announcement, cleared after a tick. */
+  readonly modeAnnouncement = signal('');
+
+  /** Row element refs for programmatic focus management. */
+  readonly countryRows = viewChildren<ElementRef<HTMLElement>>('countryRow');
+
+  /** Capital announcement derived from selection. Guards against null/undefined leaking. */
+  protected readonly announcementText = computed(() => {
+    const selected = this.selectedCountry();
+    if (selected === null || selected === undefined) {
+      return '';
+    }
+    const country = this.countries.find((c) => c.name === selected);
+    if (!country) {
+      return '';
+    }
+    return `Capital: ${country.capital}`;
+  });
+
+  /**
+   * Single aria-live region text. Mode announcements take priority,
+   * falling back to capital announcement.
+   */
+  protected readonly liveRegionText = computed(() => {
+    return this.modeAnnouncement() || this.announcementText();
+  });
+
+  /** Whether the placeholder should be visible (no selection in explore mode). */
+  protected readonly showPlaceholder = computed(() => {
+    return this.selectedCountry() === null && !this.showAll();
+  });
+
+  // TODO: emit analytics event — countries_view_loaded { timestamp: number }
+  ngAfterViewInit(): void {
+    // Component rendered — analytics hook point
+  }
+
+  selectCountry(name: string): void {
+    // No-op in show-all mode
+    if (this.showAll()) {
+      return;
+    }
+
+    if (this.selectedCountry() === name) {
+      // Toggle off (deselect)
+      this.selectedCountry.set(null);
+      // TODO: emit analytics event — country_deselected { country_name: string }
+    } else {
+      // Select new country — single synchronous update ensures no blank flash
+      this.selectedCountry.set(name);
+      // TODO: emit analytics event — country_selected { country_name: string, capital_name: string }
+    }
+  }
+
+  toggleShowAll(): void {
+    const previousMode = this.showAll() ? 'show_all' : 'explore';
+
+    // Clear selection synchronously before mode switch
+    this.selectedCountry.set(null);
+
+    const newShowAll = !this.showAll();
+    this.showAll.set(newShowAll);
+
+    const announcement = newShowAll
+      ? 'Mostrando todas las capitales'
+      : 'Modo exploraci\u00f3n';
+    this.modeAnnouncement.set(announcement);
+
+    // Clear after a tick so screen readers pick it up
+    setTimeout(() => this.modeAnnouncement.set(''), 0);
+
+    // TODO: emit analytics event — show_all_toggled { mode: string, previous_mode: string }
+    void previousMode; // used for future analytics
+  }
+
+  /**
+   * Keyboard handler for country rows. Uses roving tabindex with clamping.
+   * ARIA APG recommends no wrapping for short lists so users have a clear
+   * sense of list boundaries.
+   */
+  onCountryKeydown(event: KeyboardEvent, index: number): void {
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        const next = Math.min(index + 1, this.countries.length - 1);
+        this.focusedIndex.set(next);
+        this.focusRow(next);
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        const prev = Math.max(index - 1, 0);
+        this.focusedIndex.set(prev);
+        this.focusRow(prev);
+        break;
+      }
+      case 'Enter':
+        this.selectCountry(this.countries[index].name);
+        break;
+      case ' ':
+        // Prevent page scroll on Space
+        event.preventDefault();
+        this.selectCountry(this.countries[index].name);
+        break;
+    }
+  }
+
+  protected isSelected(name: string): boolean {
+    return this.selectedCountry() === name;
+  }
+
+  protected getCapital(name: string): string {
+    return this.countries.find((c) => c.name === name)?.capital ?? '';
+  }
+
+  private focusRow(index: number): void {
+    const rows = this.countryRows();
+    if (rows[index]) {
+      rows[index].nativeElement.focus();
+    }
+  }
+}

--- a/src/app/features/countries/country.model.ts
+++ b/src/app/features/countries/country.model.ts
@@ -1,0 +1,23 @@
+export interface Country {
+  name: string;
+  capital: string;
+  flag: string;
+}
+
+// French Guiana (Guayana Francesa) is excluded from this list because it is an
+// overseas territory of France, not a sovereign state.
+export const SOUTH_AMERICAN_COUNTRIES: readonly Country[] = [
+  { name: 'Argentina', capital: 'Buenos Aires', flag: '\u{1F1E6}\u{1F1F7}' },
+  // Bolivia: constitutional capital is Sucre; La Paz is seat of government. Using Sucre per constitutional designation. Confirm with PO.
+  { name: 'Bolivia', capital: 'Sucre', flag: '\u{1F1E7}\u{1F1F4}' },
+  { name: 'Brasil', capital: 'Brasilia', flag: '\u{1F1E7}\u{1F1F7}' },
+  { name: 'Chile', capital: 'Santiago', flag: '\u{1F1E8}\u{1F1F1}' },
+  { name: 'Colombia', capital: 'Bogot\u00e1', flag: '\u{1F1E8}\u{1F1F4}' },
+  { name: 'Ecuador', capital: 'Quito', flag: '\u{1F1EA}\u{1F1E8}' },
+  { name: 'Guyana', capital: 'Georgetown', flag: '\u{1F1EC}\u{1F1FE}' },
+  { name: 'Paraguay', capital: 'Asunci\u00f3n', flag: '\u{1F1F5}\u{1F1FE}' },
+  { name: 'Per\u00fa', capital: 'Lima', flag: '\u{1F1F5}\u{1F1EA}' },
+  { name: 'Surinam', capital: 'Paramaribo', flag: '\u{1F1F8}\u{1F1F7}' },
+  { name: 'Uruguay', capital: 'Montevideo', flag: '\u{1F1FA}\u{1F1FE}' },
+  { name: 'Venezuela', capital: 'Caracas', flag: '\u{1F1FB}\u{1F1EA}' },
+];

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@analogjs/vitest-angular/setup-zone';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import angular from '@analogjs/vite-plugin-angular';
+
+export default defineConfig({
+  plugins: [angular()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
+    include: ['src/**/*.spec.ts'],
+  },
+});


### PR DESCRIPTION
## Story
**SAM1-107**: **Hypothesis**

## Acceptance Criteria
- **Initial Load:** Given the user navigates to `/countries`, When the page renders, Then all 12 sovereign South American countries are displayed alphabetically with flag emojis and chevron indicators, the heading 'Capitales de Sudamérica' is visible, the toggle button 'Ver todas las capitales' (with `aria-expanded="false"`) is visible above the list without scrolling at 320px width, and the placeholder text 'Selecciona un país para ver su capital' is shown.
- **Country Selection:** Given no country is selected, When the user clicks a country, Then the capital city appears inline beneath that country with a slide-down animation ≤180 ms, the row is visually highlighted (left-border accent + background tint + checkmark + chevron rotation), the placeholder fades out and becomes `aria-hidden="true"`, and the `aria-live` region announces 'Capital: [city]'.
- **Toggle Deselect:** Given a country is already selected, When the user clicks the same country again, Then the capital collapses with a slide-up animation, the highlight and chevron clear, and the placeholder text fades back in with `aria-hidden="false"`.
- **Switch Selection:** Given a country is selected, When the user clicks a different country, Then the previous capital is dismissed and the new capital is shown in a single fluid motion with no intermediate blank flash, both transitions firing in the same change detection cycle.
- **Show All Toggle:** Given the user is in explore mode, When the user clicks 'Ver todas las capitales', Then any active selection is cleared immediately (even mid-animation), all 12 countries with flag emojis and capitals are displayed in a semantic two-column table (`<table>`/`<caption>`/`<thead>`/`<th scope="col">`), the button label changes to 'Explorar una por una' with `aria-expanded="true"`, and the `aria-live` region briefly announces 'Mostrando todas las capitales'.
- **Keyboard Navigation:** Given the user is navigating via keyboard, When they Tab to the list, use Arrow Up/Down (clamped at boundaries, no wrapping), and press Enter or Space, Then the country is selected, focus stays on the row, Space does not scroll the page (`preventDefault` called), and a visible `:focus-visible` ring (2px offset, ≥3:1 contrast) is present at all times.
- **Screen Reader Accessibility:** Given a screen reader is active, When a country is selected, Then the capital is announced via a persistent `aria-live="polite"` region containing 'Capital: [city]'; each row has correct `aria-expanded` and `aria-selected` attributes; when deselected the region is emptied (never 'Capital: undefined' or 'Capital: null'); placeholder text is `aria-hidden` when not visible.
- **Rapid Re-selection & Mid-Animation Toggle:** Given the user clicks multiple countries in quick succession or toggles show-all mid-animation, When the UI updates, Then only the most recently selected country's capital is displayed, CSS transitions are interruptible without stacking or flickering, no stale data is shown, and toggling show-all mid-animation cleanly switches to table mode with no ghost expanded rows.

## Implementation Details
### Architecture


# Technical Architecture Review — Countries Capital Explorer

## Data Model

**File: `src/app/features/countries/country.model.ts`**

Define a `Country` interface with three string fields: `name`, `capital`, and `flag`. Export a `readonly Country[]` constant named `SOUTH_AMERICAN_COUNTRIES`, pre-sorted alphabetically by `name`. All values in Spanish common short names.

Directly above the array declaration, place a comment explaining the exclusion of French Guiana as an overseas territory of France, not a sovereign state. On the Bolivia entry, add a comment noting that Sucre is the constitut

### Developer Notes
**Data Model — `src/app/features/countries/country.model.ts`**

- `Country` interface: `{ name: string; capital: string; flag: string }`
- `SOUTH_AMERICAN_COUNTRIES` as a `readonly Country[]`, pre-sorted alphabetically by `name`. All values in Spanish common short names.
- The 12 countries: Argentina (Buenos Aires), Bolivia (Sucre), Brasil (Brasilia), Chile (Santiago), Colombia (Bogotá), Ecuador (Quito), Guyana (Georgetown), Paraguay (Asunción), Perú (Lima), Surinam (Paramaribo), Uruguay (Montevideo), Venezuela (Caracas).
- French Guiana exclusion comment directly above the array declaration.


## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/countries.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/countries/country.model.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=As a user, I want to select a country from a list of South American countries and see its corresponding capital displayed, so that I can quickly look up capital cities by country. -->
<!-- bmad:team_id=SAM1 -->