### PR TITLE
feat(SAM1): add to-do feature to the app (no backend, super simple) [SAM1-258]

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'todo',
+    loadComponent: () =>
+      import('./features/todo/todo-list.component').then(m => m.TodoListComponent),
+  },
+];

--- a/src/app/features/todo/analytics.service.ts
+++ b/src/app/features/todo/analytics.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+
+export abstract class AnalyticsService {
+  abstract trackItemAdded(title: string, timestamp: string): void;
+  abstract trackItemToggled(itemId: string, completed: boolean): void;
+  abstract trackItemDeleted(itemId: string): void;
+  abstract trackPageViewed(itemCount: number): void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConsoleAnalyticsService extends AnalyticsService {
+  trackItemAdded(title: string, timestamp: string): void {
+    console.debug('todo_item_added', { title, timestamp });
+  }
+
+  trackItemToggled(itemId: string, completed: boolean): void {
+    console.debug('todo_item_toggled', { itemId, completed });
+  }
+
+  trackItemDeleted(itemId: string): void {
+    console.debug('todo_item_deleted', { itemId });
+  }
+
+  trackPageViewed(itemCount: number): void {
+    console.debug('todo_page_viewed', { itemCount });
+  }
+}

--- a/src/app/features/todo/storage.token.ts
+++ b/src/app/features/todo/storage.token.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+
+export const STORAGE = new InjectionToken<Storage>('Storage', {
+  providedIn: 'root',
+  factory: () => localStorage,
+});

--- a/src/app/features/todo/todo-edge-cases.spec.ts
+++ b/src/app/features/todo/todo-edge-cases.spec.ts
@@ -1,0 +1,264 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TodoListComponent } from './todo-list.component';
+import { TodoService } from './todo.service';
+import { STORAGE } from './storage.token';
+import { AnalyticsService, ConsoleAnalyticsService } from './analytics.service';
+import { CURRENT_STORAGE_VERSION, TodoStorage, generateId } from './todo.model';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+describe('generateId', () => {
+  it('should return a non-empty string', () => {
+    const id = generateId();
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe('string');
+  });
+
+  it('should return unique IDs', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateId()));
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe('ConsoleAnalyticsService', () => {
+  it('should call console.debug for each tracking method', () => {
+    const svc = new ConsoleAnalyticsService();
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    svc.trackItemAdded('Test', '2026-01-01T00:00:00Z');
+    expect(spy).toHaveBeenCalledWith('todo_item_added', { title: 'Test', timestamp: '2026-01-01T00:00:00Z' });
+
+    svc.trackItemToggled('id1', true);
+    expect(spy).toHaveBeenCalledWith('todo_item_toggled', { itemId: 'id1', completed: true });
+
+    svc.trackItemDeleted('id2');
+    expect(spy).toHaveBeenCalledWith('todo_item_deleted', { itemId: 'id2' });
+
+    svc.trackPageViewed(5);
+    expect(spy).toHaveBeenCalledWith('todo_page_viewed', { itemCount: 5 });
+
+    spy.mockRestore();
+  });
+});
+
+describe('Route configuration', () => {
+  it('should lazy-load TodoListComponent at /todo', async () => {
+    const { routes } = await import('../../app.routes');
+    const todoRoute = routes.find(r => r.path === 'todo');
+    expect(todoRoute).toBeTruthy();
+    expect(todoRoute!.loadComponent).toBeDefined();
+
+    const mod = await (todoRoute!.loadComponent as () => Promise<any>)();
+    expect(mod).toBe(TodoListComponent);
+  });
+});
+
+describe('TodoListComponent - edge cases', () => {
+  let fixture: ComponentFixture<TodoListComponent>;
+  let component: TodoListComponent;
+  let mockStorage: Storage;
+  let service: TodoService;
+  let analyticsSpy: {
+    trackItemAdded: ReturnType<typeof vi.fn>;
+    trackItemToggled: ReturnType<typeof vi.fn>;
+    trackItemDeleted: ReturnType<typeof vi.fn>;
+    trackPageViewed: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    mockStorage = createMockStorage();
+    analyticsSpy = {
+      trackItemAdded: vi.fn(),
+      trackItemToggled: vi.fn(),
+      trackItemDeleted: vi.fn(),
+      trackPageViewed: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    })
+    .overrideComponent(TodoListComponent, {
+      set: {
+        providers: [{ provide: AnalyticsService, useValue: analyticsSpy }],
+      },
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(TodoService);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should track page viewed on init', () => {
+    expect(analyticsSpy.trackPageViewed).toHaveBeenCalledWith(0);
+  });
+
+  it('should track item added with analytics', () => {
+    component.newTitle = 'Analytics test';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(analyticsSpy.trackItemAdded).toHaveBeenCalledWith('Analytics test', expect.any(String));
+  });
+
+  it('should track item toggled with analytics', () => {
+    service.add('Toggle track');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.todo-checkbox').click();
+    fixture.detectChanges();
+
+    expect(analyticsSpy.trackItemToggled).toHaveBeenCalledWith(
+      expect.any(String),
+      true,
+    );
+  });
+
+  it('should track item deleted after undo window expires', () => {
+    service.add('Delete track');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.delete-btn').click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    expect(analyticsSpy.trackItemDeleted).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(4000);
+    fixture.detectChanges();
+
+    expect(analyticsSpy.trackItemDeleted).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('should not track deleted if undo is clicked', () => {
+    service.add('Undo track');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.delete-btn').click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.undo-btn').click();
+    fixture.detectChanges();
+
+    vi.advanceTimersByTime(4000);
+    expect(analyticsSpy.trackItemDeleted).not.toHaveBeenCalled();
+  });
+
+  it('should disable add button for 200ms after add (double-click guard)', () => {
+    component.newTitle = 'Quick add';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector('.add-btn') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    vi.advanceTimersByTime(200);
+    fixture.detectChanges();
+    expect(component.addDisabled()).toBe(false);
+  });
+
+  it('should have maxlength 200 on input', () => {
+    const input = fixture.nativeElement.querySelector('.todo-input');
+    expect(input.getAttribute('maxlength')).toBe('200');
+  });
+
+  it('should return focus to input after adding', () => {
+    component.newTitle = 'Focus test';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('.todo-input'));
+  });
+
+  it('should restore item at original index on undo', () => {
+    service.add('A');
+    service.add('B');
+    service.add('C');
+    fixture.detectChanges();
+    // Order: C(0), B(1), A(2)
+
+    // Delete B (index 1)
+    const deleteBtns = fixture.nativeElement.querySelectorAll('.delete-btn');
+    deleteBtns[1].click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    // Undo
+    fixture.nativeElement.querySelector('.undo-btn').click();
+    fixture.detectChanges();
+
+    const titles = Array.from(fixture.nativeElement.querySelectorAll('.todo-title'))
+      .map((el: any) => el.textContent.trim());
+    expect(titles).toEqual(['C', 'B', 'A']);
+  });
+
+  it('should clear newTitle after successful add', () => {
+    component.newTitle = 'Clear me';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.newTitle).toBe('');
+  });
+
+  it('should handle rapid adds correctly', () => {
+    component.newTitle = 'One';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    vi.advanceTimersByTime(200);
+
+    component.newTitle = 'Two';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(service.items().length).toBe(2);
+  });
+
+  it('should persist toggle to localStorage', () => {
+    service.add('Persist toggle');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.todo-checkbox').click();
+    fixture.detectChanges();
+
+    const parsed: TodoStorage = JSON.parse(mockStorage.getItem('todo_items')!);
+    expect(parsed.items[0].completed).toBe(true);
+  });
+
+  it('should have storage-notice role=alert', () => {
+    const brokenStorage = createMockStorage();
+    brokenStorage.getItem = () => { throw new Error('SecurityError'); };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [{ provide: STORAGE, useValue: brokenStorage }],
+    });
+    const fix2 = TestBed.createComponent(TodoListComponent);
+    fix2.detectChanges();
+
+    const notice = fix2.nativeElement.querySelector('.storage-notice');
+    expect(notice.getAttribute('role')).toBe('alert');
+    warnSpy.mockRestore();
+  });
+});

--- a/src/app/features/todo/todo-list.component.spec.ts
+++ b/src/app/features/todo/todo-list.component.spec.ts
@@ -1,0 +1,268 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TodoListComponent } from './todo-list.component';
+import { TodoService } from './todo.service';
+import { STORAGE } from './storage.token';
+import { AnalyticsService, ConsoleAnalyticsService } from './analytics.service';
+import { CURRENT_STORAGE_VERSION, TodoStorage } from './todo.model';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+describe('TodoListComponent', () => {
+  let fixture: ComponentFixture<TodoListComponent>;
+  let component: TodoListComponent;
+  let mockStorage: Storage;
+  let service: TodoService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    mockStorage = createMockStorage();
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(TodoService);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show empty state when no items', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const emptyState = el.querySelector('[role="status"].empty-state');
+    expect(emptyState).toBeTruthy();
+    expect(emptyState!.textContent).toContain('No to-dos yet. Add one above!');
+  });
+
+  it('should auto-focus input on load', () => {
+    const input = fixture.nativeElement.querySelector('.todo-input');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('should add an item on form submit', () => {
+    component.newTitle = 'Test task';
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.todo-item');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('Test task');
+  });
+
+  it('should save to localStorage in versioned envelope on add', () => {
+    component.newTitle = 'Persist me';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    const raw = mockStorage.getItem('todo_items');
+    const parsed: TodoStorage = JSON.parse(raw!);
+    expect(parsed.version).toBe(CURRENT_STORAGE_VERSION);
+    expect(parsed.items[0].title).toBe('Persist me');
+  });
+
+  it('should show validation hint for empty input', () => {
+    component.newTitle = '   ';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    const hint = fixture.nativeElement.querySelector('#validation-hint');
+    expect(hint).toBeTruthy();
+    expect(hint!.textContent).toContain('Give your task a name first.');
+    expect(hint!.getAttribute('aria-live')).toBe('assertive');
+
+    // Input has aria-describedby
+    const input = fixture.nativeElement.querySelector('.todo-input');
+    expect(input.getAttribute('aria-describedby')).toBe('validation-hint');
+  });
+
+  it('should clear validation hint when user types', () => {
+    component.newTitle = '';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+    expect(component.validationHint()).toBeTruthy();
+
+    // Simulate typing
+    component.onInputChange();
+    fixture.detectChanges();
+    expect(component.validationHint()).toBe('');
+  });
+
+  it('should toggle item completion', () => {
+    service.add('Toggle task');
+    fixture.detectChanges();
+
+    const checkbox = fixture.nativeElement.querySelector('.todo-checkbox') as HTMLInputElement;
+    checkbox.click();
+    fixture.detectChanges();
+
+    const item = fixture.nativeElement.querySelector('.todo-item');
+    expect(item.classList.contains('completed')).toBe(true);
+
+    // Verify persisted
+    const parsed: TodoStorage = JSON.parse(mockStorage.getItem('todo_items')!);
+    expect(parsed.items[0].completed).toBe(true);
+  });
+
+  it('should apply completed class on completed items', () => {
+    service.add('Style test');
+    fixture.detectChanges();
+
+    const checkbox = fixture.nativeElement.querySelector('.todo-checkbox') as HTMLInputElement;
+    checkbox.click();
+    fixture.detectChanges();
+
+    const item = fixture.nativeElement.querySelector('.todo-item');
+    expect(item.classList.contains('completed')).toBe(true);
+  });
+
+  it('should delete item and show undo toast', () => {
+    service.add('Delete me');
+    fixture.detectChanges();
+
+    const deleteBtn = fixture.nativeElement.querySelector('.delete-btn');
+    deleteBtn.click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    // Item removed from list
+    expect(fixture.nativeElement.querySelectorAll('.todo-item').length).toBe(0);
+
+    // Undo toast visible
+    const toast = fixture.nativeElement.querySelector('.undo-toast');
+    expect(toast).toBeTruthy();
+    expect(toast!.textContent).toContain('Delete me');
+
+    // Click undo
+    const undoBtn = fixture.nativeElement.querySelector('.undo-btn');
+    undoBtn.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('.todo-item').length).toBe(1);
+    expect(fixture.nativeElement.querySelector('.undo-toast')).toBeFalsy();
+  });
+
+  it('should finalize delete after 4 seconds', () => {
+    service.add('Gone soon');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.delete-btn').click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    vi.advanceTimersByTime(4000);
+    fixture.detectChanges();
+
+    // Toast gone
+    expect(fixture.nativeElement.querySelector('.undo-toast')).toBeFalsy();
+
+    // Persisted without the item
+    const parsed: TodoStorage = JSON.parse(mockStorage.getItem('todo_items')!);
+    expect(parsed.items.length).toBe(0);
+  });
+
+  it('should have proper aria-labels on checkboxes and delete buttons', () => {
+    service.add('Accessible task');
+    fixture.detectChanges();
+
+    const checkbox = fixture.nativeElement.querySelector('.todo-checkbox');
+    expect(checkbox.getAttribute('aria-label')).toContain("Mark 'Accessible task' as complete");
+
+    const deleteBtn = fixture.nativeElement.querySelector('.delete-btn');
+    expect(deleteBtn.getAttribute('aria-label')).toContain("Delete 'Accessible task'");
+  });
+
+  it('should use semantic ul/li elements', () => {
+    service.add('Semantic');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ul.todo-list')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('li.todo-item')).toBeTruthy();
+  });
+
+  it('should show storage unavailable notice', () => {
+    const brokenStorage = createMockStorage();
+    brokenStorage.getItem = () => { throw new Error('SecurityError'); };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+      providers: [
+        { provide: STORAGE, useValue: brokenStorage },
+      ],
+    });
+    const fix2 = TestBed.createComponent(TodoListComponent);
+    fix2.detectChanges();
+
+    const notice = fix2.nativeElement.querySelector('.storage-notice');
+    expect(notice).toBeTruthy();
+    expect(notice!.textContent).toContain("won't persist");
+    warnSpy.mockRestore();
+  });
+
+  it('should not create item for whitespace-only input', () => {
+    component.newTitle = '   \t  ';
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(service.items().length).toBe(0);
+  });
+
+  it('should add items at the top of the list', () => {
+    service.add('First');
+    service.add('Second');
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.todo-title');
+    expect(items[0].textContent).toContain('Second');
+    expect(items[1].textContent).toContain('First');
+  });
+
+  it('should finalize previous pending delete when new delete happens', () => {
+    service.add('Item 1');
+    service.add('Item 2');
+    fixture.detectChanges();
+
+    // Delete first item (Item 2 is at index 0)
+    const deleteBtns = fixture.nativeElement.querySelectorAll('.delete-btn');
+    deleteBtns[0].click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    // Delete next item
+    const deleteBtns2 = fixture.nativeElement.querySelectorAll('.delete-btn');
+    deleteBtns2[0].click();
+    vi.advanceTimersByTime(0);
+    fixture.detectChanges();
+
+    // Both deleted from DOM
+    expect(fixture.nativeElement.querySelectorAll('.todo-item').length).toBe(0);
+
+    vi.advanceTimersByTime(4000);
+    fixture.detectChanges();
+
+    const parsed: TodoStorage = JSON.parse(mockStorage.getItem('todo_items')!);
+    expect(parsed.items.length).toBe(0);
+  });
+});

--- a/src/app/features/todo/todo-list.component.ts
+++ b/src/app/features/todo/todo-list.component.ts
@@ -1,0 +1,361 @@
+import {
+  Component,
+  inject,
+  signal,
+  OnInit,
+  OnDestroy,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TodoService } from './todo.service';
+import { TodoItem } from './todo.model';
+import { AnalyticsService, ConsoleAnalyticsService } from './analytics.service';
+
+interface PendingDelete {
+  item: TodoItem;
+  index: number;
+  timerId: ReturnType<typeof setTimeout>;
+}
+
+@Component({
+  selector: 'app-todo-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  providers: [{ provide: AnalyticsService, useClass: ConsoleAnalyticsService }],
+  template: `
+    <div class="todo-container">
+      <h1>To-Do List</h1>
+
+      @if (!todoService.storageAvailable()) {
+        <div class="storage-notice" role="alert">
+          Tasks won't persist after closing the tab (localStorage unavailable).
+        </div>
+      }
+
+      <form class="todo-form" (ngSubmit)="onAdd()" novalidate>
+        <div class="input-group">
+          <input
+            #titleInput
+            type="text"
+            [(ngModel)]="newTitle"
+            name="title"
+            placeholder="What needs to be done?"
+            maxlength="200"
+            [attr.aria-describedby]="validationHint() ? 'validation-hint' : null"
+            (input)="onInputChange()"
+            class="todo-input"
+          />
+          <button
+            type="submit"
+            class="add-btn"
+            [disabled]="addDisabled()"
+          >Add</button>
+        </div>
+        @if (validationHint()) {
+          <p
+            id="validation-hint"
+            class="validation-hint"
+            aria-live="assertive"
+          >{{ validationHint() }}</p>
+        }
+      </form>
+
+      @if (todoService.items().length === 0 && !pendingDelete()) {
+        <div role="status" class="empty-state">
+          <span class="empty-icon" aria-hidden="true">&#128203;</span>
+          <p>No to-dos yet. Add one above!</p>
+        </div>
+      } @else {
+        <ul class="todo-list">
+          @for (item of todoService.items(); track item.id; let i = $index) {
+            <li
+              class="todo-item"
+              [class.completed]="item.completed"
+              [class.new-item]="item.id === lastAddedId()"
+              [attr.data-id]="item.id"
+            >
+              <input
+                type="checkbox"
+                [checked]="item.completed"
+                (change)="onToggle(item)"
+                [attr.aria-label]="'Mark \\'' + item.title + '\\' as complete'"
+                class="todo-checkbox"
+              />
+              <span class="todo-title">{{ item.title }}</span>
+              <button
+                type="button"
+                (click)="onDelete(item, i)"
+                [attr.aria-label]="'Delete \\'' + item.title + '\\''"
+                class="delete-btn"
+              >&times;</button>
+            </li>
+          }
+        </ul>
+      }
+
+      @if (pendingDelete()) {
+        <div class="undo-toast" role="status">
+          <span>Deleted "{{ pendingDelete()!.item.title }}"</span>
+          <button type="button" (click)="onUndo()" class="undo-btn">Undo</button>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .todo-container {
+      max-width: 600px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    h1 { text-align: center; margin-bottom: 1.5rem; }
+    .storage-notice {
+      background: #fff3cd;
+      border: 1px solid #ffc107;
+      border-radius: 6px;
+      padding: 0.5rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+      color: #856404;
+    }
+    .todo-form { margin-bottom: 1.5rem; }
+    .input-group { display: flex; gap: 0.5rem; }
+    .todo-input {
+      flex: 1;
+      padding: 0.75rem;
+      font-size: 1rem;
+      border: 2px solid #ccc;
+      border-radius: 6px;
+      min-height: 44px;
+      box-sizing: border-box;
+    }
+    .todo-input:focus { border-color: #4a90d9; outline: none; }
+    .add-btn {
+      padding: 0 1.25rem;
+      font-size: 1rem;
+      min-width: 44px;
+      min-height: 44px;
+      border: none;
+      border-radius: 6px;
+      background: #4a90d9;
+      color: white;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .add-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+    .add-btn:hover:not(:disabled) { background: #357abd; }
+    .validation-hint {
+      color: #c0392b;
+      font-size: 0.875rem;
+      margin: 0.25rem 0 0;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: #888;
+    }
+    .empty-icon { font-size: 3rem; display: block; margin-bottom: 0.5rem; }
+    .todo-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .todo-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem;
+      border-bottom: 1px solid #eee;
+    }
+    .todo-item.completed .todo-title {
+      text-decoration: line-through;
+      opacity: 0.55;
+    }
+    .todo-checkbox {
+      min-width: 44px;
+      min-height: 44px;
+      width: 22px;
+      height: 22px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .todo-title {
+      flex: 1;
+      word-break: break-word;
+      font-size: 1rem;
+    }
+    .delete-btn {
+      background: none;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      min-width: 44px;
+      min-height: 44px;
+      font-size: 1.25rem;
+      cursor: pointer;
+      color: #c0392b;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .delete-btn:hover { background: #fdecea; }
+    .undo-toast {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: #333;
+      color: white;
+      padding: 0.75rem 1rem;
+      border-radius: 6px;
+      margin-top: 1rem;
+    }
+    .undo-btn {
+      background: transparent;
+      border: 1px solid white;
+      color: white;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+      min-width: 44px;
+      min-height: 44px;
+      font-size: 0.875rem;
+    }
+    .undo-btn:hover { background: rgba(255,255,255,0.15); }
+
+    @media (prefers-reduced-motion: no-preference) {
+      @keyframes fadeIn {
+        from { background-color: #e8f4fd; }
+        to { background-color: transparent; }
+      }
+      .new-item {
+        animation: fadeIn 400ms ease-out;
+      }
+    }
+  `],
+})
+export class TodoListComponent implements OnInit, OnDestroy, AfterViewInit {
+  readonly todoService = inject(TodoService);
+  private readonly analytics = inject(AnalyticsService);
+
+  @ViewChild('titleInput') titleInputRef!: ElementRef<HTMLInputElement>;
+
+  newTitle = '';
+  readonly validationHint = signal('');
+  readonly addDisabled = signal(false);
+  readonly pendingDelete = signal<PendingDelete | null>(null);
+  readonly lastAddedId = signal<string | null>(null);
+
+  private lastAddedTimer: ReturnType<typeof setTimeout> | null = null;
+  private addDisabledTimer: ReturnType<typeof setTimeout> | null = null;
+  private destroyed = false;
+
+  ngOnInit(): void {
+    this.analytics.trackPageViewed(this.todoService.items().length);
+  }
+
+  ngAfterViewInit(): void {
+    this.titleInputRef?.nativeElement?.focus();
+  }
+
+  ngOnDestroy(): void {
+    // Finalize any pending delete
+    const pending = this.pendingDelete();
+    if (pending) {
+      clearTimeout(pending.timerId);
+      this.todoService.finalizeDelete();
+      this.analytics.trackItemDeleted(pending.item.id);
+    }
+    if (this.lastAddedTimer) clearTimeout(this.lastAddedTimer);
+    if (this.addDisabledTimer) clearTimeout(this.addDisabledTimer);
+    this.destroyed = true;
+  }
+
+  onInputChange(): void {
+    if (this.validationHint()) {
+      this.validationHint.set('');
+    }
+  }
+
+  onAdd(): void {
+    const title = this.newTitle.trim();
+    if (!title) {
+      this.validationHint.set('Give your task a name first.');
+      return;
+    }
+
+    const item = this.todoService.add(title);
+    this.analytics.trackItemAdded(title, item.createdAt);
+    this.newTitle = '';
+    this.validationHint.set('');
+
+    // Show new-item animation
+    this.lastAddedId.set(item.id);
+    if (this.lastAddedTimer) clearTimeout(this.lastAddedTimer);
+    this.lastAddedTimer = setTimeout(() => this.lastAddedId.set(null), 500);
+
+    // Debounce add button
+    this.addDisabled.set(true);
+    if (this.addDisabledTimer) clearTimeout(this.addDisabledTimer);
+    this.addDisabledTimer = setTimeout(() => {
+      if (!this.destroyed) this.addDisabled.set(false);
+      this.addDisabledTimer = null;
+    }, 200);
+
+    // Return focus to input
+    requestAnimationFrame(() => {
+      if (!this.destroyed) this.titleInputRef?.nativeElement?.focus();
+    });
+  }
+
+  onToggle(item: TodoItem): void {
+    this.todoService.toggle(item.id);
+    const toggled = this.todoService.items().find(i => i.id === item.id);
+    this.analytics.trackItemToggled(item.id, toggled?.completed ?? !item.completed);
+  }
+
+  onDelete(item: TodoItem, index: number): void {
+    // Finalize any previous pending delete
+    const prev = this.pendingDelete();
+    if (prev) {
+      clearTimeout(prev.timerId);
+      this.todoService.finalizeDelete();
+      this.analytics.trackItemDeleted(prev.item.id);
+    }
+
+    const deleted = this.todoService.delete(item.id);
+    if (!deleted) return;
+
+    const timerId = setTimeout(() => {
+      this.todoService.finalizeDelete();
+      this.analytics.trackItemDeleted(deleted.id);
+      this.pendingDelete.set(null);
+    }, 4000);
+
+    this.pendingDelete.set({ item: deleted, index, timerId });
+
+    // Focus management: next item, previous item, or input
+    // Use requestAnimationFrame to wait for Angular's DOM update cycle
+    requestAnimationFrame(() => {
+      if (this.destroyed) return;
+      const items = this.todoService.items();
+      if (items.length > 0) {
+        const targetIndex = index < items.length ? index : items.length - 1;
+        const targetId = items[targetIndex].id;
+        const el = document.querySelector<HTMLElement>(`.todo-item[data-id="${targetId}"] .todo-checkbox`);
+        if (el) { el.focus(); return; }
+      }
+      this.titleInputRef?.nativeElement?.focus();
+    });
+  }
+
+  onUndo(): void {
+    const pending = this.pendingDelete();
+    if (!pending) return;
+    clearTimeout(pending.timerId);
+    this.todoService.restoreDeleted(pending.item, pending.index);
+    this.pendingDelete.set(null);
+  }
+}

--- a/src/app/features/todo/todo.model.ts
+++ b/src/app/features/todo/todo.model.ts
@@ -1,0 +1,26 @@
+export interface TodoItem {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: string; // ISO-8601
+}
+
+export interface TodoStorage {
+  version: number;
+  items: TodoItem[];
+}
+
+export const CURRENT_STORAGE_VERSION = 1;
+
+export type TodoTrackingEvent =
+  | { name: 'todo_item_added'; meta: { title: string; timestamp: string } }
+  | { name: 'todo_item_toggled'; meta: { itemId: string; completed: boolean } }
+  | { name: 'todo_item_deleted'; meta: { itemId: string } }
+  | { name: 'todo_page_viewed'; meta: { itemCount: number } };
+
+export function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}

--- a/src/app/features/todo/todo.service.spec.ts
+++ b/src/app/features/todo/todo.service.spec.ts
@@ -1,0 +1,192 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoService } from './todo.service';
+import { STORAGE } from './storage.token';
+import { CURRENT_STORAGE_VERSION, TodoStorage } from './todo.model';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+describe('TodoService', () => {
+  let service: TodoService;
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    });
+    service = TestBed.inject(TodoService);
+  });
+
+  it('should start with empty items', () => {
+    expect(service.items()).toEqual([]);
+    expect(service.storageAvailable()).toBe(true);
+  });
+
+  it('should add an item at the top', () => {
+    service.add('First');
+    service.add('Second');
+    expect(service.items().length).toBe(2);
+    expect(service.items()[0].title).toBe('Second');
+    expect(service.items()[1].title).toBe('First');
+  });
+
+  it('should persist items in versioned envelope', () => {
+    service.add('Test');
+    const raw = mockStorage.getItem('todo_items');
+    expect(raw).toBeTruthy();
+    const parsed: TodoStorage = JSON.parse(raw!);
+    expect(parsed.version).toBe(CURRENT_STORAGE_VERSION);
+    expect(parsed.items.length).toBe(1);
+    expect(parsed.items[0].title).toBe('Test');
+  });
+
+  it('should toggle item completion', () => {
+    service.add('Toggle me');
+    const id = service.items()[0].id;
+    expect(service.items()[0].completed).toBe(false);
+    service.toggle(id);
+    expect(service.items()[0].completed).toBe(true);
+    service.toggle(id);
+    expect(service.items()[0].completed).toBe(false);
+  });
+
+  it('should delete and restore items', () => {
+    service.add('Keep');
+    service.add('Delete me');
+    const id = service.items()[0].id;
+    const deleted = service.delete(id);
+    expect(deleted).toBeTruthy();
+    expect(deleted!.title).toBe('Delete me');
+    expect(service.items().length).toBe(1);
+
+    service.restoreDeleted(deleted!, 0);
+    expect(service.items().length).toBe(2);
+    expect(service.items()[0].title).toBe('Delete me');
+  });
+
+  it('should finalize delete by persisting', () => {
+    service.add('To delete');
+    service.delete(service.items()[0].id);
+    service.finalizeDelete();
+    const parsed: TodoStorage = JSON.parse(mockStorage.getItem('todo_items')!);
+    expect(parsed.items.length).toBe(0);
+  });
+
+  it('should hydrate from localStorage on construction', () => {
+    const envelope: TodoStorage = {
+      version: 1,
+      items: [{ id: '1', title: 'Saved', completed: true, createdAt: '2026-01-01T00:00:00.000Z' }],
+    };
+    mockStorage.setItem('todo_items', JSON.stringify(envelope));
+
+    const service2 = TestBed.inject(TodoService);
+    // Same instance due to providedIn root, so create fresh
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    });
+    const freshService = TestBed.inject(TodoService);
+    expect(freshService.items().length).toBe(1);
+    expect(freshService.items()[0].title).toBe('Saved');
+    expect(freshService.items()[0].completed).toBe(true);
+  });
+
+  it('should handle corrupted localStorage data', () => {
+    mockStorage.setItem('todo_items', 'not json');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    });
+    const freshService = TestBed.inject(TodoService);
+    expect(freshService.items()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(mockStorage.getItem('todo_items')).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it('should handle unrecognized storage format', () => {
+    mockStorage.setItem('todo_items', JSON.stringify({ foo: 'bar' }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: mockStorage },
+      ],
+    });
+    const freshService = TestBed.inject(TodoService);
+    expect(freshService.items()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should handle localStorage unavailable (throws on getItem)', () => {
+    const brokenStorage = createMockStorage();
+    brokenStorage.getItem = () => { throw new Error('SecurityError'); };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: brokenStorage },
+      ],
+    });
+    const freshService = TestBed.inject(TodoService);
+    expect(freshService.items()).toEqual([]);
+    expect(freshService.storageAvailable()).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('should handle quota exceeded on persist', () => {
+    const quotaStorage = createMockStorage();
+    quotaStorage.setItem = () => { throw new Error('QuotaExceededError'); };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        TodoService,
+        { provide: STORAGE, useValue: quotaStorage },
+      ],
+    });
+    const freshService = TestBed.inject(TodoService);
+    freshService.add('Test');
+    // Item still added in-memory
+    expect(freshService.items().length).toBe(1);
+    expect(freshService.storageAvailable()).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('should generate items with proper fields', () => {
+    const item = service.add('My task');
+    expect(item.id).toBeTruthy();
+    expect(item.title).toBe('My task');
+    expect(item.completed).toBe(false);
+    expect(item.createdAt).toBeTruthy();
+    // Verify ISO-8601
+    expect(new Date(item.createdAt).toISOString()).toBe(item.createdAt);
+  });
+});

--- a/src/app/features/todo/todo.service.ts
+++ b/src/app/features/todo/todo.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { TodoItem, TodoStorage, CURRENT_STORAGE_VERSION, generateId } from './todo.model';
+import { STORAGE } from './storage.token';
+
+const STORAGE_KEY = 'todo_items';
+
+@Injectable({ providedIn: 'root' })
+export class TodoService {
+  private readonly storage = inject(STORAGE);
+  private readonly _items = signal<TodoItem[]>([]);
+  private readonly _storageAvailable = signal(true);
+
+  readonly items = this._items.asReadonly();
+  readonly storageAvailable = this._storageAvailable.asReadonly();
+
+  constructor() {
+    this.hydrate();
+  }
+
+  private hydrate(): void {
+    try {
+      const raw = this.storage.getItem(STORAGE_KEY);
+      if (raw === null) {
+        this._items.set([]);
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && Array.isArray(parsed.items) && typeof parsed.version === 'number') {
+        this._items.set(parsed.items);
+      } else {
+        // Legacy or corrupted format
+        console.warn('TodoService: corrupted or unrecognized storage format. Clearing.');
+        this.storage.removeItem(STORAGE_KEY);
+        this._items.set([]);
+      }
+    } catch (e) {
+      console.warn('TodoService: failed to parse localStorage data. Falling back to empty.', e);
+      try {
+        this.storage.removeItem(STORAGE_KEY);
+      } catch {
+        // storage completely unavailable
+      }
+      this._storageAvailable.set(false);
+      this._items.set([]);
+    }
+  }
+
+  private persist(): void {
+    try {
+      const envelope: TodoStorage = {
+        version: CURRENT_STORAGE_VERSION,
+        items: this._items(),
+      };
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(envelope));
+    } catch (e) {
+      console.warn('TodoService: failed to persist to localStorage.', e);
+      this._storageAvailable.set(false);
+    }
+  }
+
+  add(title: string): TodoItem {
+    const item: TodoItem = {
+      id: generateId(),
+      title,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    };
+    this._items.update(items => [item, ...items]);
+    this.persist();
+    return item;
+  }
+
+  toggle(id: string): void {
+    this._items.update(items =>
+      items.map(item =>
+        item.id === id ? { ...item, completed: !item.completed } : item
+      )
+    );
+    this.persist();
+  }
+
+  delete(id: string): TodoItem | undefined {
+    let deleted: TodoItem | undefined;
+    this._items.update(items => {
+      const idx = items.findIndex(i => i.id === id);
+      if (idx === -1) return items;
+      deleted = items[idx];
+      const copy = [...items];
+      copy.splice(idx, 1);
+      return copy;
+    });
+    // Persist immediately so closing the browser won't lose the deletion
+    this.persist();
+    return deleted;
+  }
+
+  restoreDeleted(item: TodoItem, index?: number): void {
+    this._items.update(items => {
+      const copy = [...items];
+      const clampedIndex = index !== undefined && index >= 0 ? Math.min(index, copy.length) : 0;
+      copy.splice(clampedIndex, 0, item);
+      return copy;
+    });
+    this.persist();
+  }
+
+  /** Called after undo window expires to finalize deletion in storage */
+  finalizeDelete(): void {
+    this.persist();
+  }
+}


### PR DESCRIPTION
## Story
**SAM1-258**: **Hypothesis**

## Acceptance Criteria
- Given the user is on /todo, when they type a non-empty title and click 'Add' or press Enter, then the item appears at the top of the list, is saved to localStorage in the versioned TodoStorage envelope, and focus returns to the input field.
- Given the input field is empty or contains only whitespace, when the user clicks 'Add' or presses Enter, then no item is created and an inline validation hint ('Give your task a name first') appears below the input linked via aria-describedby with aria-live='assertive', clearing when the user starts typing.
- Given a to-do item exists, when the user clicks the checkbox, then the item's completed state toggles, styling updates to strikethrough plus opacity 0.55, and the change is persisted to localStorage.
- Given a to-do item exists, when the user clicks the delete button, then the item is removed from the visible list immediately and a 4-second undo toast appears; clicking 'Undo' restores the item; if the timer expires the item is permanently removed from localStorage and the todo_item_deleted event fires.
- Given items exist in the list, when the user reloads the page, then all items are restored from localStorage with correct title, completed, and createdAt state via the versioned TodoStorage envelope.
- Given no to-do items exist, when the user views /todo, then a friendly empty-state message is displayed in a role='status' live region with the input field auto-focused.
- Given the to-do list is rendered, when inspected by a screen reader, then each checkbox has aria-label including the item title, each delete button has aria-label including the item title, the list uses semantic ul/li elements, and all interactive elements meet 44x44px minimum tap targets.
- Given localStorage is unavailable or contains corrupted data, when the service initializes, then the feature works in-memory for the session, a subtle notice informs the user that tasks won't persist, and corrupted data is cleared with a console.warn.

## Implementation Details
### Architecture


# Technical Architecture Review: Todo List Feature

## Data Model

The feature introduces a single client-side entity. Define it as a TypeScript interface in a dedicated file at `src/app/features/todo/todo.model.ts`:

```typescript
export interface TodoItem {
  id: string;
  title: string;
  completed: boolean;
  createdAt: string; // ISO-8601
}
```

- Use `crypto.randomUUID()` for `id` generation. It's available in all modern browsers and avoids pulling in a UUID library. Provide a fallback of `Date.now().toString(36) + Math.random().toString(36).slice(2)` only if you must support older Web

### Developer Notes
**File Structure**

- `src/app/features/todo/todo.model.ts` — `TodoItem` interface and `TodoStorage` envelope (`{ version: number, items: TodoItem[] }`). Export `TodoTrackingEvent` type union for the four analytics events.
- `src/app/features/todo/storage.token.ts` — `InjectionToken<Storage>` named `STORAGE` with `factory: () => localStorage`. This is the seam for testing and graceful degradation.
- `src/app/features/todo/todo.service.ts` — Signal-based state management. Private `WritableSignal<TodoItem[]>`, public readonly signal. Injects `STORAGE` token. Hydrates on construction with try/cat

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/storage.token.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-edge-cases.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=add to-do feature to the app (no backend, super simple) -->
<!-- bmad:team_id=SAM1 -->