### PR TITLE
feat(SAM1): create a todo feature for this app (no backend, super simple [SAM1-264]

### DIFF
--- a/e2e/todo.spec.ts
+++ b/e2e/todo.spec.ts
@@ -1,0 +1,300 @@
+import { test, expect, Page } from '@playwright/test';
+
+const STORAGE_KEY = 'todos_app_data';
+
+async function seedStorage(page: Page, todos: Array<{ id: string; title: string; completed: boolean; createdAt: string }>) {
+  await page.evaluate((data) => {
+    localStorage.setItem('todos_app_data', JSON.stringify({ version: 1, todos: data }));
+  }, todos);
+}
+
+function makeTodo(title: string, completed = false, id?: string): { id: string; title: string; completed: boolean; createdAt: string } {
+  return {
+    id: id ?? Math.random().toString(36).slice(2),
+    title,
+    completed,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  // Clear localStorage before each test by navigating and clearing
+  await page.goto('/todo');
+  await page.evaluate(() => localStorage.removeItem('todos_app_data'));
+});
+
+test.describe('Todo App - Add Todo', () => {
+  test('adds a todo via Enter key, clears input, persists to localStorage', async ({ page }) => {
+    await page.goto('/todo');
+
+    const input = page.getByLabel('New todo title');
+    await input.fill('Buy groceries');
+    await input.press('Enter');
+
+    // Todo appears in the list
+    await expect(page.getByText('Buy groceries')).toBeVisible();
+    // Input is cleared
+    await expect(input).toHaveValue('');
+    // Focus remains on input
+    await expect(input).toBeFocused();
+
+    // Persisted to localStorage with versioned schema
+    const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('todos_app_data')!));
+    expect(stored.version).toBe(1);
+    expect(stored.todos).toHaveLength(1);
+    expect(stored.todos[0].title).toBe('Buy groceries');
+    expect(stored.todos[0].completed).toBe(false);
+  });
+
+  test('adds a todo via Add button click', async ({ page }) => {
+    await page.goto('/todo');
+
+    await page.getByLabel('New todo title').fill('Walk the dog');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    await expect(page.getByText('Walk the dog')).toBeVisible();
+  });
+
+  test('does not add empty or whitespace-only todos', async ({ page }) => {
+    await page.goto('/todo');
+
+    const input = page.getByLabel('New todo title');
+
+    // Press Enter with empty input
+    await input.press('Enter');
+    await expect(page.getByText('No tasks yet. Add one above to get started.')).toBeVisible();
+
+    // Whitespace only
+    await input.fill('   ');
+    await input.press('Enter');
+    await expect(page.getByText('No tasks yet. Add one above to get started.')).toBeVisible();
+  });
+
+  test('newest todos appear at top of list', async ({ page }) => {
+    await page.goto('/todo');
+
+    const input = page.getByLabel('New todo title');
+    await input.fill('First');
+    await input.press('Enter');
+    await input.fill('Second');
+    await input.press('Enter');
+
+    const items = page.getByRole('list').getByRole('listitem');
+    // "Second" should be first (newest-first)
+    await expect(items.first()).toContainText('Second');
+  });
+});
+
+test.describe('Todo App - Toggle Complete', () => {
+  test('toggles a todo between completed and active', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Task A', false, 'id-a')]);
+    await page.goto('/todo');
+
+    const checkbox = page.getByRole('checkbox', { name: 'Task A' });
+    await expect(checkbox).not.toBeChecked();
+
+    // Complete it
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+
+    // Verify localStorage updated
+    const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('todos_app_data')!));
+    expect(stored.todos[0].completed).toBe(true);
+
+    // Toggle back
+    await checkbox.uncheck();
+    await expect(checkbox).not.toBeChecked();
+  });
+});
+
+test.describe('Todo App - Delete with Undo', () => {
+  test('deletes a todo and shows undo snackbar', async ({ page }) => {
+    await seedStorage(page, [makeTodo('To delete', false, 'id-del')]);
+    await page.goto('/todo');
+
+    await expect(page.getByText('To delete')).toBeVisible();
+    await page.getByRole('button', { name: 'Delete task: To delete' }).click();
+
+    // Todo removed from list
+    await expect(page.getByText('To delete')).not.toBeVisible();
+    // Snackbar visible
+    await expect(page.getByText('Task deleted.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Undo' })).toBeVisible();
+  });
+
+  test('undo restores the deleted todo', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Restore me', false, 'id-restore')]);
+    await page.goto('/todo');
+
+    await page.getByRole('button', { name: 'Delete task: Restore me' }).click();
+    await expect(page.getByText('Restore me')).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'Undo' }).click();
+    await expect(page.getByText('Restore me')).toBeVisible();
+  });
+
+  test('snackbar disappears after 4 seconds and deletion is finalized', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Gone soon', false, 'id-gone')]);
+    await page.goto('/todo');
+
+    await page.getByRole('button', { name: 'Delete task: Gone soon' }).click();
+    await expect(page.getByText('Task deleted.')).toBeVisible();
+
+    // Wait for snackbar to disappear (4s undo window)
+    await expect(page.getByText('Task deleted.')).not.toBeVisible({ timeout: 6000 });
+
+    // Verify finalized in localStorage
+    const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('todos_app_data')!));
+    expect(stored.todos).toHaveLength(0);
+  });
+});
+
+test.describe('Todo App - Filters', () => {
+  test('filters todos by All / Active / Completed', async ({ page }) => {
+    await seedStorage(page, [
+      makeTodo('Active task', false, 'id-1'),
+      makeTodo('Done task', true, 'id-2'),
+    ]);
+    await page.goto('/todo');
+
+    // All filter - both visible
+    await expect(page.getByText('Active task')).toBeVisible();
+    await expect(page.getByText('Done task')).toBeVisible();
+
+    // Active filter
+    await page.getByRole('radio', { name: 'Active' }).click();
+    await expect(page.getByText('Active task')).toBeVisible();
+    await expect(page.getByText('Done task')).not.toBeVisible();
+
+    // Completed filter
+    await page.getByRole('radio', { name: 'Completed' }).click();
+    await expect(page.getByText('Done task')).toBeVisible();
+    await expect(page.getByText('Active task')).not.toBeVisible();
+  });
+
+  test('shows contextual empty state messages per filter', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Only active', false, 'id-1')]);
+    await page.goto('/todo');
+
+    await page.getByRole('radio', { name: 'Completed' }).click();
+    await expect(page.getByText('No completed tasks.')).toBeVisible();
+  });
+
+  test('adding a todo on Completed filter auto-switches to All', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Done one', true, 'id-1')]);
+    await page.goto('/todo');
+
+    await page.getByRole('radio', { name: 'Completed' }).click();
+    await expect(page.getByRole('radio', { name: 'Completed' })).toHaveAttribute('aria-checked', 'true');
+
+    const input = page.getByLabel('New todo title');
+    await input.fill('New task');
+    await input.press('Enter');
+
+    // Filter should switch to All
+    await expect(page.getByRole('radio', { name: 'All' })).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByText('New task')).toBeVisible();
+  });
+});
+
+test.describe('Todo App - Persistence', () => {
+  test('todos survive page refresh', async ({ page }) => {
+    await page.goto('/todo');
+
+    const input = page.getByLabel('New todo title');
+    await input.fill('Persistent task');
+    await input.press('Enter');
+    await expect(page.getByText('Persistent task')).toBeVisible();
+
+    // Refresh
+    await page.reload();
+    await expect(page.getByText('Persistent task')).toBeVisible();
+  });
+
+  test('corrupted localStorage falls back to empty list', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('todos_app_data', 'NOT VALID JSON{{{');
+    });
+    await page.goto('/todo');
+
+    // Should show empty state, not crash
+    await expect(page.getByText('No tasks yet. Add one above to get started.')).toBeVisible();
+  });
+});
+
+test.describe('Todo App - Clear Completed', () => {
+  test('clears all completed todos with undo', async ({ page }) => {
+    await seedStorage(page, [
+      makeTodo('Keep this task', false, 'id-1'),
+      makeTodo('Done 1', true, 'id-2'),
+      makeTodo('Done 2', true, 'id-3'),
+    ]);
+    await page.goto('/todo');
+
+    await page.getByRole('button', { name: 'Clear completed' }).click();
+
+    // Completed todos gone
+    await expect(page.getByText('Done 1')).not.toBeVisible();
+    await expect(page.getByText('Done 2')).not.toBeVisible();
+    // Active todo remains
+    await expect(page.getByText('Keep this task')).toBeVisible();
+
+    // Undo restores them
+    await page.getByRole('button', { name: 'Undo' }).click();
+    await expect(page.getByText('Done 1')).toBeVisible();
+    await expect(page.getByText('Done 2')).toBeVisible();
+  });
+
+  test('Clear completed button hidden when no completed todos', async ({ page }) => {
+    await seedStorage(page, [makeTodo('Active only', false, 'id-1')]);
+    await page.goto('/todo');
+
+    await expect(page.getByRole('button', { name: 'Clear completed' })).not.toBeVisible();
+  });
+});
+
+test.describe('Todo App - Accessibility', () => {
+  test('has proper ARIA structure', async ({ page }) => {
+    await seedStorage(page, [makeTodo('A11y task', false, 'id-a11y')]);
+    await page.goto('/todo');
+
+    // Semantic list
+    await expect(page.getByRole('list')).toBeVisible();
+    await expect(page.getByRole('listitem').first()).toBeVisible();
+
+    // Checkbox with label
+    await expect(page.getByRole('checkbox', { name: 'A11y task' })).toBeVisible();
+
+    // Delete button with aria-label
+    await expect(page.getByRole('button', { name: 'Delete task: A11y task' })).toBeAttached();
+
+    // Filter radiogroup
+    await expect(page.getByRole('radiogroup', { name: 'Filter todos' })).toBeVisible();
+    await expect(page.getByRole('radio', { name: 'All' })).toBeVisible();
+    await expect(page.getByRole('radio', { name: 'All' })).toHaveAttribute('aria-checked', 'true');
+
+    // Items left with aria-live
+    await expect(page.getByText('1 item left')).toBeVisible();
+  });
+});
+
+test.describe('Todo App - Empty State', () => {
+  test('shows empty state when no todos exist', async ({ page }) => {
+    await page.goto('/todo');
+    await expect(page.getByText('No tasks yet. Add one above to get started.')).toBeVisible();
+  });
+});
+
+test.describe('Todo App - Items Left Count', () => {
+  test('displays correct item count', async ({ page }) => {
+    await seedStorage(page, [
+      makeTodo('One', false, 'id-1'),
+      makeTodo('Two', false, 'id-2'),
+      makeTodo('Three', true, 'id-3'),
+    ]);
+    await page.goto('/todo');
+
+    // 2 active items
+    await expect(page.getByText('2 items left')).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4200',
+    headless: true,
+  },
+  webServer: {
+    command: 'npx ng serve --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { routes } from './app.routes';
+
+describe('App Routes', () => {
+  it('should have a lazy-loaded todo route', () => {
+    const todoRoute = routes.find(r => r.path === 'todo');
+    expect(todoRoute).toBeTruthy();
+    expect(todoRoute!.loadComponent).toBeDefined();
+    expect(typeof todoRoute!.loadComponent).toBe('function');
+  });
+
+  it('should lazy-load TodoListComponent', async () => {
+    const todoRoute = routes.find(r => r.path === 'todo')!;
+    const component = await (todoRoute.loadComponent as () => Promise<any>)();
+    expect(component).toBeDefined();
+    expect(typeof component).toBe('function');
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'todo',
+    loadComponent: () =>
+      import('./features/todo/todo-list.component').then(m => m.TodoListComponent),
+  },
+];

--- a/src/app/features/todo/todo-list.component.extra.spec.ts
+++ b/src/app/features/todo/todo-list.component.extra.spec.ts
@@ -1,0 +1,242 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoListComponent } from './todo-list.component';
+import { TodoService } from './todo.service';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+describe('TodoListComponent — additional tests', () => {
+  let mockStorage: Storage;
+
+  beforeEach(async () => {
+    mockStorage = createMockStorage();
+    Object.defineProperty(globalThis, 'localStorage', { value: mockStorage, writable: true, configurable: true });
+    vi.stubGlobal('crypto', { randomUUID: () => `test-${Date.now()}-${Math.random()}` });
+
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should have input with maxlength=250 and autocomplete=off', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const input = el.querySelector('input[name="newTodo"]') as HTMLInputElement;
+    expect(input.getAttribute('maxlength')).toBe('250');
+    expect(input.getAttribute('autocomplete')).toBe('off');
+  });
+
+  it('should have placeholder text on input', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const input = el.querySelector('input[name="newTodo"]') as HTMLInputElement;
+    expect(input.placeholder).toBe('What needs to be done?');
+  });
+
+  it('should show storage warning banner when storage is unavailable', () => {
+    // Make storage fail
+    mockStorage.setItem = () => { throw new DOMException('QuotaExceededError'); };
+    mockStorage.removeItem = () => { throw new DOMException('QuotaExceededError'); };
+
+    // Recreate TestBed so service picks up failing storage
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ imports: [TodoListComponent] });
+
+    const fixture = TestBed.createComponent(TodoListComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const warning = el.querySelector('.storage-warning');
+    expect(warning).toBeTruthy();
+    expect(warning!.textContent).toContain("Changes won't be saved");
+  });
+
+  it('should show undo snackbar after deleting a todo', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Delete me');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const deleteBtn = el.querySelector('.delete-btn') as HTMLButtonElement;
+    deleteBtn.click();
+    fixture.detectChanges();
+
+    const snackbar = el.querySelector('.snackbar');
+    expect(snackbar).toBeTruthy();
+    expect(snackbar!.textContent).toContain('Task deleted');
+    expect(el.querySelector('.undo-btn')).toBeTruthy();
+  });
+
+  it('should restore todo when undo button is clicked', async () => {
+    vi.useFakeTimers();
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Restore me');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    el.querySelector<HTMLButtonElement>('.delete-btn')!.click();
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('.todo-item').length).toBe(0);
+
+    el.querySelector<HTMLButtonElement>('.undo-btn')!.click();
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('.todo-item').length).toBe(1);
+    expect(el.querySelector('.todo-title')!.textContent).toContain('Restore me');
+    vi.useRealTimers();
+  });
+
+  it('should toggle todo via checkbox click', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Toggle via UI');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const checkbox = el.querySelector('.todo-checkbox') as HTMLInputElement;
+    checkbox.click();
+    fixture.detectChanges();
+
+    expect(el.querySelector('.todo-item')!.classList.contains('completed')).toBe(true);
+  });
+
+  it('should display correct items left count', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('One');
+    service.addTodo('Two');
+    service.addTodo('Three');
+    service.toggleTodo(service.todos()[0].id);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const itemsLeft = el.querySelector('.items-left')!.textContent!.trim();
+    expect(itemsLeft).toContain('2 items left');
+  });
+
+  it('should show "1 item left" (singular) when only one active', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Only one');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const itemsLeft = el.querySelector('.items-left')!.textContent!.trim();
+    expect(itemsLeft).toContain('1 item left');
+    expect(itemsLeft).not.toContain('items');
+  });
+
+  it('should clear input after adding todo', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+
+    const input = el.querySelector('input[name="newTodo"]') as HTMLInputElement;
+    input.value = 'Clear me';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    el.querySelector('form')!.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance['newTodoTitle']).toBe('');
+  });
+
+  it('should not add todo when input is empty', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    el.querySelector('form')!.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(service.todos().length).toBe(0);
+  });
+
+  it('should switch filter when filter button is clicked', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const filterBtns = el.querySelectorAll('.filter-btn');
+    expect(filterBtns.length).toBe(3);
+
+    // Click "Active"
+    (filterBtns[1] as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect(service.filter()).toBe('active');
+    expect(filterBtns[1].getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('should use semantic ul structure with role=list', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const ul = el.querySelector('ul[role="list"]');
+    expect(ul).toBeTruthy();
+  });
+
+  it('should render delete button as a real button element', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Has button');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const deleteBtn = el.querySelector('.delete-btn');
+    expect(deleteBtn).toBeTruthy();
+    expect(deleteBtn!.tagName).toBe('BUTTON');
+  });
+
+  it('should render checkbox as real input[type=checkbox]', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Has checkbox');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const checkbox = el.querySelector('.todo-checkbox') as HTMLInputElement;
+    expect(checkbox.tagName).toBe('INPUT');
+    expect(checkbox.type).toBe('checkbox');
+  });
+
+  it('should clear completed via button click', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Active');
+    service.addTodo('Done');
+    service.toggleTodo(service.todos()[0].id);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const clearBtn = el.querySelector('.clear-completed-btn') as HTMLButtonElement;
+    expect(clearBtn).toBeTruthy();
+    clearBtn.click();
+    fixture.detectChanges();
+
+    expect(service.todos().length).toBe(1);
+    expect(el.querySelector('.snackbar')).toBeTruthy();
+  });
+});

--- a/src/app/features/todo/todo-list.component.spec.ts
+++ b/src/app/features/todo/todo-list.component.spec.ts
@@ -1,0 +1,161 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoListComponent } from './todo-list.component';
+import { TodoService } from './todo.service';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock localStorage
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+describe('TodoListComponent', () => {
+  let mockStorage: Storage;
+
+  beforeEach(async () => {
+    mockStorage = createMockStorage();
+    Object.defineProperty(globalThis, 'localStorage', { value: mockStorage, writable: true, configurable: true });
+    vi.stubGlobal('crypto', { randomUUID: () => `test-${Date.now()}-${Math.random()}` });
+
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create the component', () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should show empty state message when no todos', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('No tasks yet. Add one above to get started.');
+  });
+
+  it('should add a todo via form submission', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+
+    const input = el.querySelector('input[name="newTodo"]') as HTMLInputElement;
+    const form = el.querySelector('form')!;
+
+    input.value = 'New task';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(el.querySelector('.todo-title')?.textContent).toContain('New task');
+  });
+
+  it('should have accessible delete buttons with aria-label', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('My task');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const deleteBtn = el.querySelector('.delete-btn') as HTMLButtonElement;
+    expect(deleteBtn.getAttribute('aria-label')).toBe('Delete task: My task');
+  });
+
+  it('should have checkbox with associated label', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Labeled task');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const checkbox = el.querySelector('.todo-checkbox') as HTMLInputElement;
+    const label = el.querySelector('.todo-title') as HTMLLabelElement;
+    expect(checkbox.id).toBeTruthy();
+    expect(label.getAttribute('for')).toBe(checkbox.id);
+  });
+
+  it('should use role=radiogroup for filters', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    const radiogroup = el.querySelector('[role="radiogroup"]');
+    expect(radiogroup).toBeTruthy();
+    const radios = el.querySelectorAll('[role="radio"]');
+    expect(radios.length).toBe(3);
+  });
+
+  it('should have aria-live region for items left', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    const liveRegion = el.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeTruthy();
+    expect(liveRegion!.textContent).toContain('0 items left');
+  });
+
+  it('should use semantic ul/li structure', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    const ul = el.querySelector('ul.todo-list');
+    expect(ul).toBeTruthy();
+  });
+
+  it('should show contextual empty state for active filter', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Task');
+    service.toggleTodo(service.todos()[0].id);
+    service.setFilter('active');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('No active tasks.');
+  });
+
+  it('should show contextual empty state for completed filter', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    service.addTodo('Task');
+    service.setFilter('completed');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('No completed tasks.');
+  });
+
+  it('should show clear completed button only when completed todos exist', async () => {
+    const fixture = TestBed.createComponent(TodoListComponent);
+    const service = TestBed.inject(TodoService);
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.clear-completed-btn')).toBeNull();
+
+    service.addTodo('Task');
+    service.toggleTodo(service.todos()[0].id);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(el.querySelector('.clear-completed-btn')).toBeTruthy();
+  });
+});

--- a/src/app/features/todo/todo-list.component.ts
+++ b/src/app/features/todo/todo-list.component.ts
@@ -1,0 +1,399 @@
+import { Component, inject, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TodoService } from './todo.service';
+import { TodoFilter } from './todo.model';
+
+@Component({
+  selector: 'app-todo-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    @if (!todoService.storageAvailable()) {
+      <div class="storage-warning" role="alert">
+        Your browser storage is full or unavailable. Changes won't be saved.
+      </div>
+    }
+
+    <div class="todo-container">
+      <h1>Todos</h1>
+
+      <form (ngSubmit)="addTodo()" class="todo-input-row">
+        <input
+          #todoInput
+          type="text"
+          [(ngModel)]="newTodoTitle"
+          name="newTodo"
+          placeholder="What needs to be done?"
+          autocomplete="off"
+          maxlength="250"
+          aria-label="New todo title"
+        />
+        <button type="submit" class="add-btn">Add</button>
+      </form>
+
+      <ul class="todo-list" role="list">
+        @for (todo of todoService.filteredTodos(); track todo.id) {
+          <li
+            class="todo-item"
+            [class.completed]="todo.completed"
+            [class.new-item]="todo.id === todoService.newTodoId()"
+            [attr.data-todo-id]="todo.id"
+          >
+            <input
+              type="checkbox"
+              [id]="'todo-' + todo.id"
+              [checked]="todo.completed"
+              (change)="todoService.toggleTodo(todo.id)"
+              class="todo-checkbox"
+            />
+            <label [for]="'todo-' + todo.id" class="todo-title">{{ todo.title }}</label>
+            <button
+              class="delete-btn"
+              [attr.aria-label]="'Delete task: ' + todo.title"
+              (click)="onDelete(todo.id)"
+            >&times;</button>
+          </li>
+        } @empty {
+          <li class="empty-state">
+            @if (todoService.filter() === 'all') {
+              No tasks yet. Add one above to get started.
+            } @else if (todoService.filter() === 'active') {
+              No active tasks.
+            } @else {
+              No completed tasks.
+            }
+          </li>
+        }
+      </ul>
+
+      @if (todoService.showUndo()) {
+        <div class="snackbar" role="status" aria-live="polite">
+          {{ todoService.undoMessage() }}
+          <button class="undo-btn" (click)="todoService.undoDelete()">Undo</button>
+        </div>
+      }
+
+      <div class="footer">
+        <div class="filters" role="radiogroup" aria-label="Filter todos">
+          @for (f of filters; track f.value) {
+            <button
+              role="radio"
+              [attr.aria-checked]="todoService.filter() === f.value"
+              [class.selected]="todoService.filter() === f.value"
+              (click)="todoService.setFilter(f.value)"
+              class="filter-btn"
+            >{{ f.label }}</button>
+          }
+        </div>
+
+        <span class="items-left" aria-live="polite">
+          {{ todoService.stats().active }} item{{ todoService.stats().active === 1 ? '' : 's' }} left
+        </span>
+
+        @if (todoService.stats().completed > 0) {
+          <button class="clear-completed-btn" (click)="todoService.clearCompleted()">
+            Clear completed
+          </button>
+        }
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      padding: 1rem;
+    }
+
+    .storage-warning {
+      background: #fff3cd;
+      color: #856404;
+      border: 1px solid #ffc107;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      margin: 0 auto 1rem;
+      max-width: 600px;
+      text-align: center;
+      font-size: 0.9rem;
+    }
+
+    .todo-container {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      text-align: center;
+      font-size: 2rem;
+      color: #333;
+      margin-bottom: 1rem;
+    }
+
+    .todo-input-row {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .todo-input-row input {
+      flex: 1;
+      padding: 0.75rem 1rem;
+      font-size: 1rem;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 150ms ease;
+    }
+
+    .todo-input-row input:focus {
+      border-color: #4a90d9;
+    }
+
+    .add-btn {
+      padding: 0.75rem 1.5rem;
+      font-size: 1rem;
+      background: #4a90d9;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      min-width: 44px;
+      min-height: 44px;
+      transition: background 150ms ease;
+    }
+
+    .add-btn:hover, .add-btn:focus {
+      background: #357abd;
+    }
+
+    .todo-list {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 0.5rem;
+    }
+
+    .todo-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem;
+      border-bottom: 1px solid #eee;
+      transition: opacity 200ms ease, background-color 500ms ease;
+      animation: fadeIn 150ms ease;
+    }
+
+    .todo-item.completed {
+      opacity: 0.5;
+    }
+
+    .todo-item.completed .todo-title {
+      text-decoration: line-through;
+    }
+
+    .todo-item.new-item {
+      background-color: #fefcbf;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(-8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .todo-checkbox {
+      width: 20px;
+      height: 20px;
+      min-width: 44px;
+      min-height: 44px;
+      cursor: pointer;
+      accent-color: #4a90d9;
+    }
+
+    .todo-title {
+      flex: 1;
+      font-size: 1rem;
+      color: #333;
+      word-break: break-word;
+      cursor: pointer;
+      padding: 0.25rem 0;
+    }
+
+    .delete-btn {
+      background: none;
+      border: none;
+      color: #ccc;
+      font-size: 1.5rem;
+      cursor: pointer;
+      min-width: 44px;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+      transition: color 150ms ease, background 150ms ease;
+    }
+
+    @media (pointer: fine) {
+      .delete-btn {
+        opacity: 0;
+      }
+      .todo-item:hover .delete-btn,
+      .todo-item:focus-within .delete-btn,
+      .delete-btn:focus {
+        opacity: 1;
+      }
+    }
+
+    @media (pointer: coarse) {
+      .delete-btn {
+        opacity: 0.5;
+      }
+    }
+
+    .delete-btn:hover, .delete-btn:focus {
+      color: #e53e3e;
+      background: #fee;
+    }
+
+    .empty-state {
+      padding: 2rem 1rem;
+      text-align: center;
+      color: #999;
+      font-size: 0.95rem;
+    }
+
+    .snackbar {
+      background: #333;
+      color: white;
+      padding: 0.75rem 1rem;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.75rem;
+      animation: fadeIn 150ms ease;
+    }
+
+    .undo-btn {
+      background: none;
+      border: none;
+      color: #68d391;
+      font-weight: 600;
+      cursor: pointer;
+      font-size: 0.95rem;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0 0.5rem;
+    }
+
+    .undo-btn:hover, .undo-btn:focus {
+      text-decoration: underline;
+    }
+
+    .footer {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 0;
+      border-top: 1px solid #eee;
+    }
+
+    .filters {
+      display: flex;
+      gap: 0;
+      border-radius: 6px;
+      overflow: hidden;
+      border: 1px solid #ddd;
+    }
+
+    .filter-btn {
+      padding: 0.5rem 1rem;
+      font-size: 0.85rem;
+      border: none;
+      background: white;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+      transition: background 150ms ease, color 150ms ease;
+    }
+
+    .filter-btn + .filter-btn {
+      border-left: 1px solid #ddd;
+    }
+
+    .filter-btn.selected {
+      background: #4a90d9;
+      color: white;
+    }
+
+    .filter-btn:hover:not(.selected) {
+      background: #f0f0f0;
+    }
+
+    .items-left {
+      font-size: 0.85rem;
+      color: #888;
+      margin-left: auto;
+    }
+
+    .clear-completed-btn {
+      padding: 0.5rem 1rem;
+      font-size: 0.85rem;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      background: white;
+      cursor: pointer;
+      min-height: 44px;
+      transition: background 150ms ease;
+    }
+
+    .clear-completed-btn:hover, .clear-completed-btn:focus {
+      background: #f0f0f0;
+    }
+  `],
+})
+export class TodoListComponent {
+  protected readonly todoService = inject(TodoService);
+  protected newTodoTitle = '';
+
+  @ViewChild('todoInput', { static: true }) todoInputRef!: ElementRef<HTMLInputElement>;
+
+  readonly filters: { label: string; value: TodoFilter }[] = [
+    { label: 'All', value: 'all' },
+    { label: 'Active', value: 'active' },
+    { label: 'Completed', value: 'completed' },
+  ];
+
+  addTodo(): void {
+    const before = this.todoService.todos().length;
+    this.todoService.addTodo(this.newTodoTitle);
+    if (this.todoService.todos().length > before) {
+      this.newTodoTitle = '';
+    }
+    this.todoInputRef.nativeElement.focus();
+  }
+
+  onDelete(id: string): void {
+    // Determine the next item to focus before deleting
+    const items = this.todoService.filteredTodos();
+    const deletedIndex = items.findIndex(t => t.id === id);
+
+    this.todoService.deleteTodo(id);
+
+    // Focus management: move focus to next todo or input
+    setTimeout(() => {
+      const remainingItems = this.todoService.filteredTodos();
+      if (remainingItems.length === 0) {
+        this.todoInputRef.nativeElement.focus();
+      } else {
+        // Focus the item that now occupies the deleted position, or the last item
+        const focusIndex = Math.min(deletedIndex, remainingItems.length - 1);
+        const targetId = remainingItems[focusIndex].id;
+        const targetEl = document.querySelector<HTMLElement>(
+          `.todo-item[data-todo-id="${targetId}"] .todo-checkbox`
+        );
+        targetEl?.focus() || this.todoInputRef.nativeElement.focus();
+      }
+    });
+  }
+}

--- a/src/app/features/todo/todo.model.ts
+++ b/src/app/features/todo/todo.model.ts
@@ -1,0 +1,21 @@
+export interface Todo {
+  /** UUID v4 — requires secure context (HTTPS or localhost) */
+  id: string;
+  title: string;
+  completed: boolean;
+  /** ISO 8601 string — not Date, because JSON.parse does not rehydrate Date objects */
+  createdAt: string;
+}
+
+export type TodoFilter = 'all' | 'active' | 'completed';
+
+export interface TodoStorageSchema {
+  version: number;
+  todos: Todo[];
+}
+
+export interface TodoTrackingEvent {
+  eventName: 'todo_added' | 'todo_completed' | 'todo_deleted' | 'todo_filter_changed';
+  meta: Record<string, string | number>;
+  timestamp: string;
+}

--- a/src/app/features/todo/todo.service.extra.spec.ts
+++ b/src/app/features/todo/todo.service.extra.spec.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { TodoService } from './todo.service';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+describe('TodoService — additional edge cases', () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    Object.defineProperty(globalThis, 'localStorage', { value: mockStorage, writable: true, configurable: true });
+    vi.stubGlobal('crypto', { randomUUID: () => `test-${Date.now()}-${Math.random()}` });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function createService(): TodoService {
+    return new TodoService();
+  }
+
+  it('should reject titles longer than 250 characters', () => {
+    const service = createService();
+    service.addTodo('a'.repeat(251));
+    expect(service.todos().length).toBe(0);
+  });
+
+  it('should accept titles exactly 250 characters', () => {
+    const service = createService();
+    service.addTodo('a'.repeat(250));
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title.length).toBe(250);
+  });
+
+  it('should generate unique ids for each todo', () => {
+    const service = createService();
+    service.addTodo('A');
+    service.addTodo('B');
+    service.addTodo('C');
+    const ids = service.todos().map(t => t.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('should store createdAt as ISO 8601 string', () => {
+    const service = createService();
+    service.addTodo('Check date');
+    const createdAt = service.todos()[0].createdAt;
+    expect(typeof createdAt).toBe('string');
+    expect(new Date(createdAt).toISOString()).toBe(createdAt);
+  });
+
+  it('should persist under versioned schema { version: 1, todos: [...] }', () => {
+    const service = createService();
+    service.addTodo('Schema check');
+    const stored = JSON.parse(mockStorage.getItem('todos_app_data')!);
+    expect(stored.version).toBe(1);
+    expect(Array.isArray(stored.todos)).toBe(true);
+    expect(stored.todos[0].title).toBe('Schema check');
+  });
+
+  it('should handle unrecognized schema version gracefully', () => {
+    mockStorage.setItem('todos_app_data', JSON.stringify({ version: 99, todos: [] }));
+    const service = createService();
+    expect(service.todos()).toEqual([]);
+  });
+
+  it('should undo clearCompleted and restore todos', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('Active');
+    service.addTodo('Done1');
+    service.addTodo('Done2');
+    service.toggleTodo(service.todos()[0].id); // Done2
+    service.toggleTodo(service.todos()[1].id); // Done1
+
+    service.clearCompleted();
+    expect(service.todos().length).toBe(1);
+    expect(service.showUndo()).toBe(true);
+    expect(service.undoMessage()).toContain('2 tasks cleared');
+
+    service.undoDelete();
+    expect(service.todos().length).toBe(3);
+    expect(service.showUndo()).toBe(false);
+  });
+
+  it('should do nothing when clearCompleted is called with no completed todos', () => {
+    const service = createService();
+    service.addTodo('Active only');
+    service.clearCompleted();
+    expect(service.todos().length).toBe(1);
+    expect(service.showUndo()).toBe(false);
+  });
+
+  it('should not toggle a non-existent todo id', () => {
+    const service = createService();
+    service.addTodo('Exists');
+    service.toggleTodo('nonexistent-id');
+    expect(service.todos()[0].completed).toBe(false);
+  });
+
+  it('should not delete a non-existent todo id', () => {
+    const service = createService();
+    service.addTodo('Exists');
+    service.deleteTodo('nonexistent-id');
+    expect(service.todos().length).toBe(1);
+    expect(service.showUndo()).toBe(false);
+  });
+
+  it('should do nothing when undoDelete is called with no pending delete', () => {
+    const service = createService();
+    service.addTodo('Task');
+    service.undoDelete(); // no-op
+    expect(service.todos().length).toBe(1);
+  });
+
+  it('should fire todo_deleted tracking after undo window expires', () => {
+    vi.useFakeTimers();
+    const consoleSpy = vi.spyOn(console, 'log');
+    const service = createService();
+    service.addTodo('Track me');
+    consoleSpy.mockClear();
+
+    service.deleteTodo(service.todos()[0].id);
+    // Before timeout, no todo_deleted event
+    expect(consoleSpy.mock.calls.some(c => c[0].includes('todo_deleted'))).toBe(false);
+
+    vi.advanceTimersByTime(4000);
+    expect(consoleSpy.mock.calls.some(c => c[0].includes('todo_deleted'))).toBe(true);
+  });
+
+  it('should fire todo_filter_changed tracking on setFilter', () => {
+    const consoleSpy = vi.spyOn(console, 'log');
+    const service = createService();
+    service.setFilter('active');
+    expect(consoleSpy.mock.calls.some(c =>
+      c[0].includes('todo_filter_changed') && c[1]?.filterValue === 'active'
+    )).toBe(true);
+  });
+
+  it('should fire todo_completed tracking only when marking as completed', () => {
+    const consoleSpy = vi.spyOn(console, 'log');
+    const service = createService();
+    service.addTodo('Track toggle');
+    consoleSpy.mockClear();
+
+    const id = service.todos()[0].id;
+    service.toggleTodo(id); // complete
+    expect(consoleSpy.mock.calls.some(c => c[0].includes('todo_completed'))).toBe(true);
+
+    consoleSpy.mockClear();
+    service.toggleTodo(id); // uncomplete
+    expect(consoleSpy.mock.calls.some(c => c[0].includes('todo_completed'))).toBe(false);
+  });
+
+  it('should restore todo to original position on undo', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('First');
+    service.addTodo('Second');
+    service.addTodo('Third');
+    // Order: Third, Second, First
+
+    const secondId = service.todos()[1].id;
+    service.deleteTodo(secondId);
+    expect(service.todos().map(t => t.title)).toEqual(['Third', 'First']);
+
+    service.undoDelete();
+    expect(service.todos().map(t => t.title)).toEqual(['Third', 'Second', 'First']);
+  });
+
+  it('should handle rapid add operations', () => {
+    const service = createService();
+    for (let i = 0; i < 100; i++) {
+      service.addTodo(`Task ${i}`);
+    }
+    expect(service.todos().length).toBe(100);
+    expect(service.todos()[0].title).toBe('Task 99');
+  });
+
+  it('should not auto-switch filter when adding on active filter', () => {
+    const service = createService();
+    service.setFilter('active');
+    service.addTodo('New');
+    expect(service.filter()).toBe('active');
+  });
+
+  it('should compute storageSizeBytes in stats', () => {
+    const service = createService();
+    expect(service.stats().storageSizeBytes).toBeGreaterThan(0);
+    service.addTodo('More data');
+    const size = service.stats().storageSizeBytes;
+    expect(size).toBeGreaterThan(2); // non-trivial size
+  });
+
+  it('should handle null in localStorage gracefully', () => {
+    mockStorage.setItem('todos_app_data', 'null');
+    const service = createService();
+    expect(service.todos()).toEqual([]);
+  });
+
+  it('should handle empty object in localStorage gracefully', () => {
+    mockStorage.setItem('todos_app_data', JSON.stringify({}));
+    const service = createService();
+    expect(service.todos()).toEqual([]);
+  });
+
+  it('should filter out partially valid todos from storage', () => {
+    mockStorage.setItem('todos_app_data', JSON.stringify({
+      version: 1,
+      todos: [
+        { id: '1', title: 'Good', completed: false, createdAt: '2024-01-01' },
+        { id: '2', title: null, completed: false, createdAt: '2024-01-01' },
+        { id: '3', title: 'No completed field', createdAt: '2024-01-01' },
+        null,
+        undefined,
+      ],
+    }));
+    const service = createService();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].id).toBe('1');
+  });
+});

--- a/src/app/features/todo/todo.service.spec.ts
+++ b/src/app/features/todo/todo.service.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { TodoService } from './todo.service';
+
+// Mock localStorage
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+describe('TodoService', () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    Object.defineProperty(globalThis, 'localStorage', { value: mockStorage, writable: true, configurable: true });
+    vi.stubGlobal('crypto', { randomUUID: () => `test-${Date.now()}-${Math.random()}` });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function createService(): TodoService {
+    return new TodoService();
+  }
+
+  it('should start with empty todos', () => {
+    const service = createService();
+    expect(service.todos()).toEqual([]);
+    expect(service.stats().total).toBe(0);
+  });
+
+  it('should add a todo', () => {
+    const service = createService();
+    service.addTodo('Test task');
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Test task');
+    expect(service.todos()[0].completed).toBe(false);
+  });
+
+  it('should not add empty or whitespace-only todos', () => {
+    const service = createService();
+    service.addTodo('');
+    service.addTodo('   ');
+    expect(service.todos().length).toBe(0);
+  });
+
+  it('should trim todo titles', () => {
+    const service = createService();
+    service.addTodo('  Hello World  ');
+    expect(service.todos()[0].title).toBe('Hello World');
+  });
+
+  it('should prepend new todos (newest first)', () => {
+    const service = createService();
+    service.addTodo('First');
+    service.addTodo('Second');
+    expect(service.todos()[0].title).toBe('Second');
+    expect(service.todos()[1].title).toBe('First');
+  });
+
+  it('should toggle todo completion', () => {
+    const service = createService();
+    service.addTodo('Toggle me');
+    const id = service.todos()[0].id;
+
+    service.toggleTodo(id);
+    expect(service.todos()[0].completed).toBe(true);
+
+    service.toggleTodo(id);
+    expect(service.todos()[0].completed).toBe(false);
+  });
+
+  it('should delete a todo with undo support', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('Delete me');
+    const id = service.todos()[0].id;
+
+    service.deleteTodo(id);
+    expect(service.todos().length).toBe(0);
+    expect(service.showUndo()).toBe(true);
+
+    service.undoDelete();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Delete me');
+    expect(service.showUndo()).toBe(false);
+  });
+
+  it('should finalize delete after 4 seconds', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('Delete me');
+    const id = service.todos()[0].id;
+
+    service.deleteTodo(id);
+    expect(service.showUndo()).toBe(true);
+
+    vi.advanceTimersByTime(4000);
+    expect(service.showUndo()).toBe(false);
+    expect(service.todos().length).toBe(0);
+  });
+
+  it('should filter todos', () => {
+    const service = createService();
+    service.addTodo('Active task');
+    service.addTodo('Completed task');
+    service.toggleTodo(service.todos()[0].id); // Mark 'Completed task' as completed
+
+    service.setFilter('active');
+    expect(service.filteredTodos().length).toBe(1);
+    expect(service.filteredTodos()[0].title).toBe('Active task');
+
+    service.setFilter('completed');
+    expect(service.filteredTodos().length).toBe(1);
+    expect(service.filteredTodos()[0].title).toBe('Completed task');
+
+    service.setFilter('all');
+    expect(service.filteredTodos().length).toBe(2);
+  });
+
+  it('should auto-switch filter to all when adding while on completed filter', () => {
+    const service = createService();
+    service.setFilter('completed');
+    service.addTodo('New task');
+    expect(service.filter()).toBe('all');
+  });
+
+  it('should clear completed todos', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('Active');
+    service.addTodo('Done');
+    service.toggleTodo(service.todos()[0].id);
+
+    service.clearCompleted();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Active');
+    expect(service.showUndo()).toBe(true);
+  });
+
+  it('should persist and restore from localStorage', () => {
+    const service1 = createService();
+    service1.addTodo('Persisted task');
+    service1.toggleTodo(service1.todos()[0].id);
+
+    const service2 = createService();
+    expect(service2.todos().length).toBe(1);
+    expect(service2.todos()[0].title).toBe('Persisted task');
+    expect(service2.todos()[0].completed).toBe(true);
+  });
+
+  it('should handle corrupted localStorage gracefully', () => {
+    mockStorage.setItem('todos_app_data', 'not valid json!!!');
+    const service = createService();
+    expect(service.todos()).toEqual([]);
+  });
+
+  it('should handle invalid todo shapes in localStorage', () => {
+    mockStorage.setItem('todos_app_data', JSON.stringify({
+      version: 1,
+      todos: [
+        { id: 'valid', title: 'Valid', completed: false, createdAt: '2024-01-01' },
+        { id: 123, title: 'Bad ID' }, // invalid
+        'not an object', // invalid
+      ],
+    }));
+    const service = createService();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Valid');
+  });
+
+  it('should handle legacy raw array format', () => {
+    mockStorage.setItem('todos_app_data', JSON.stringify([
+      { id: 'legacy1', title: 'Legacy', completed: false, createdAt: '2024-01-01' },
+    ]));
+    const service = createService();
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('Legacy');
+  });
+
+  it('should handle localStorage write failure gracefully', () => {
+    const service = createService();
+    // Simulate quota exceeded
+    mockStorage.setItem = () => { throw new DOMException('QuotaExceededError'); };
+
+    service.addTodo('Fail to save');
+    expect(service.todos().length).toBe(1); // In-memory still works
+    expect(service.storageAvailable()).toBe(false);
+  });
+
+  it('should compute stats correctly', () => {
+    const service = createService();
+    service.addTodo('One');
+    service.addTodo('Two');
+    service.addTodo('Three');
+    service.toggleTodo(service.todos()[0].id);
+
+    const stats = service.stats();
+    expect(stats.total).toBe(3);
+    expect(stats.completed).toBe(1);
+    expect(stats.active).toBe(2);
+    expect(stats.storageSizeBytes).toBeGreaterThan(0);
+  });
+
+  it('should finalize previous pending delete when new delete occurs', () => {
+    vi.useFakeTimers();
+    const service = createService();
+    service.addTodo('First');
+    service.addTodo('Second');
+
+    service.deleteTodo(service.todos()[0].id); // Delete 'Second'
+    service.deleteTodo(service.todos()[0].id); // Delete 'First', finalizes 'Second'
+
+    service.undoDelete();
+    // Only 'First' should be restored (Second was finalized)
+    expect(service.todos().length).toBe(1);
+    expect(service.todos()[0].title).toBe('First');
+  });
+
+  it('should allow duplicate titles', () => {
+    const service = createService();
+    service.addTodo('Same title');
+    service.addTodo('Same title');
+    expect(service.todos().length).toBe(2);
+    expect(service.todos()[0].id).not.toBe(service.todos()[1].id);
+  });
+});

--- a/src/app/features/todo/todo.service.ts
+++ b/src/app/features/todo/todo.service.ts
@@ -1,0 +1,249 @@
+import { Injectable, signal, computed } from '@angular/core';
+import { Todo, TodoFilter, TodoStorageSchema, TodoTrackingEvent } from './todo.model';
+
+const STORAGE_KEY = 'todos_app_data';
+const CURRENT_VERSION = 1;
+const UNDO_TIMEOUT_MS = 4000;
+
+@Injectable({ providedIn: 'root' })
+export class TodoService {
+  private readonly todosSignal = signal<Todo[]>(this.loadFromStorage());
+  private readonly filterSignal = signal<TodoFilter>('all');
+  private readonly storageAvailableSignal = signal<boolean>(this.checkStorageAvailable());
+
+  /** Undo state — only one pending delete at a time */
+  private pendingDelete: { todos: Todo[]; indices: number[]; timeoutId: ReturnType<typeof setTimeout> } | null = null;
+  private readonly showUndoSignal = signal<boolean>(false);
+  private readonly undoMessageSignal = signal<string>('');
+
+  /** Track newly added todo id for highlight animation */
+  private readonly newTodoIdSignal = signal<string | null>(null);
+
+  readonly todos = this.todosSignal.asReadonly();
+  readonly filter = this.filterSignal.asReadonly();
+  readonly storageAvailable = this.storageAvailableSignal.asReadonly();
+  readonly showUndo = this.showUndoSignal.asReadonly();
+  readonly undoMessage = this.undoMessageSignal.asReadonly();
+  readonly newTodoId = this.newTodoIdSignal.asReadonly();
+
+  readonly filteredTodos = computed(() => {
+    const todos = this.todosSignal();
+    const filter = this.filterSignal();
+    switch (filter) {
+      case 'active': return todos.filter(t => !t.completed);
+      case 'completed': return todos.filter(t => t.completed);
+      default: return todos;
+    }
+  });
+
+  readonly stats = computed(() => {
+    const todos = this.todosSignal();
+    const completed = todos.filter(t => t.completed).length;
+    return {
+      total: todos.length,
+      completed,
+      active: todos.length - completed,
+      storageSizeBytes: new Blob([JSON.stringify(todos)]).size,
+    };
+  });
+
+  addTodo(title: string): void {
+    const trimmed = title.trim();
+    if (!trimmed || trimmed.length > 250) return;
+
+    const todo: Todo = {
+      // crypto.randomUUID() requires secure context (HTTPS or localhost)
+      id: crypto.randomUUID(),
+      title: trimmed,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.todosSignal.update(todos => [todo, ...todos]);
+
+    // Auto-switch filter to 'all' if on 'completed' so new item is visible
+    if (this.filterSignal() === 'completed') {
+      this.filterSignal.set('all');
+    }
+
+    this.newTodoIdSignal.set(todo.id);
+    setTimeout(() => {
+      if (this.newTodoIdSignal() === todo.id) {
+        this.newTodoIdSignal.set(null);
+      }
+    }, 700);
+
+    this.persist();
+    this.track('todo_added', { title: trimmed, timestamp: todo.createdAt });
+  }
+
+  toggleTodo(id: string): void {
+    this.todosSignal.update(todos =>
+      todos.map(t => t.id === id ? { ...t, completed: !t.completed } : t)
+    );
+    this.persist();
+    const todo = this.todosSignal().find(t => t.id === id);
+    if (todo?.completed) {
+      this.track('todo_completed', { todoId: id, title: todo.title });
+    }
+  }
+
+  deleteTodo(id: string): void {
+    // Finalize any pending delete immediately
+    this.finalizePendingDelete();
+
+    const todos = this.todosSignal();
+    const index = todos.findIndex(t => t.id === id);
+    if (index === -1) return;
+
+    const deletedTodo = todos[index];
+    this.todosSignal.update(t => t.filter(todo => todo.id !== id));
+
+    this.showUndoSignal.set(true);
+    this.undoMessageSignal.set('Task deleted.');
+
+    const timeoutId = setTimeout(() => {
+      this.finalizeDelete([deletedTodo], [id]);
+    }, UNDO_TIMEOUT_MS);
+
+    this.pendingDelete = { todos: [deletedTodo], indices: [index], timeoutId };
+  }
+
+  clearCompleted(): void {
+    // Finalize any pending delete immediately
+    this.finalizePendingDelete();
+
+    const todos = this.todosSignal();
+    const completedTodos: Todo[] = [];
+    const indices: number[] = [];
+    todos.forEach((t, i) => {
+      if (t.completed) {
+        completedTodos.push(t);
+        indices.push(i);
+      }
+    });
+
+    if (completedTodos.length === 0) return;
+
+    this.todosSignal.update(t => t.filter(todo => !todo.completed));
+
+    this.showUndoSignal.set(true);
+    this.undoMessageSignal.set(`${completedTodos.length} task${completedTodos.length > 1 ? 's' : ''} cleared.`);
+
+    const todoIds = completedTodos.map(t => t.id);
+    const timeoutId = setTimeout(() => {
+      this.finalizeDelete(completedTodos, todoIds);
+    }, UNDO_TIMEOUT_MS);
+
+    this.pendingDelete = { todos: completedTodos, indices, timeoutId };
+  }
+
+  undoDelete(): void {
+    if (!this.pendingDelete) return;
+
+    const { todos: deletedTodos, indices, timeoutId } = this.pendingDelete;
+    clearTimeout(timeoutId);
+
+    this.todosSignal.update(currentTodos => {
+      const result = [...currentTodos];
+      // Re-insert each deleted todo at its original index
+      for (let i = 0; i < deletedTodos.length; i++) {
+        const insertAt = Math.min(indices[i], result.length);
+        result.splice(insertAt, 0, deletedTodos[i]);
+      }
+      return result;
+    });
+
+    this.pendingDelete = null;
+    this.showUndoSignal.set(false);
+    this.persist();
+  }
+
+  setFilter(filter: TodoFilter): void {
+    this.filterSignal.set(filter);
+    this.track('todo_filter_changed', { filterValue: filter });
+  }
+
+  private finalizePendingDelete(): void {
+    if (!this.pendingDelete) return;
+    const { todos: deletedTodos, timeoutId } = this.pendingDelete;
+    clearTimeout(timeoutId);
+    this.finalizeDelete(deletedTodos, deletedTodos.map(t => t.id));
+  }
+
+  private finalizeDelete(deletedTodos: Todo[], _ids: string[]): void {
+    this.persist();
+    for (const todo of deletedTodos) {
+      this.track('todo_deleted', { todoId: todo.id, title: todo.title });
+    }
+    this.pendingDelete = null;
+    this.showUndoSignal.set(false);
+  }
+
+  private persist(): void {
+    try {
+      const schema: TodoStorageSchema = {
+        version: CURRENT_VERSION,
+        todos: this.todosSignal(),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(schema));
+      this.storageAvailableSignal.set(true);
+    } catch (e) {
+      console.error('Failed to persist todos to localStorage:', e);
+      this.storageAvailableSignal.set(false);
+    }
+  }
+
+  private loadFromStorage(): Todo[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+
+      // Handle both raw array (legacy) and versioned schema
+      if (Array.isArray(parsed)) return this.validateTodos(parsed);
+      if (parsed?.version === CURRENT_VERSION && Array.isArray(parsed.todos)) {
+        return this.validateTodos(parsed.todos);
+      }
+      console.warn('Unrecognized todo storage schema, falling back to empty list.');
+      return [];
+    } catch (e) {
+      console.warn('Failed to load todos from localStorage, falling back to empty list:', e);
+      return [];
+    }
+  }
+
+  private validateTodos(data: unknown[]): Todo[] {
+    return data.filter((item): item is Todo => {
+      if (typeof item !== 'object' || item === null) return false;
+      const t = item as Record<string, unknown>;
+      return (
+        typeof t['id'] === 'string' &&
+        typeof t['title'] === 'string' &&
+        typeof t['completed'] === 'boolean' &&
+        typeof t['createdAt'] === 'string'
+      );
+    });
+  }
+
+  private checkStorageAvailable(): boolean {
+    try {
+      const testKey = '__storage_test__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private track(eventName: TodoTrackingEvent['eventName'], meta: Record<string, string | number>): void {
+    const event: TodoTrackingEvent = {
+      eventName,
+      meta,
+      timestamp: new Date().toISOString(),
+    };
+    // Stub — replace with real analytics service injection when available
+    console.log(`[Track] ${event.eventName}`, event.meta);
+  }
+}


### PR DESCRIPTION
## Story
**SAM1-264**: **Hypothesis**

## Acceptance Criteria
- Given the todo page is loaded, When the user types a non-empty title and presses Enter or clicks Add, Then a new todo appears at the top of the list, the input clears, focus remains in the input, and the todo is persisted to localStorage under versioned schema { version: 1, todos: Todo[] }. If the input is empty or whitespace-only, no todo is created and no error is shown.
- Given an active todo exists, When the user clicks the checkbox, Then the todo is marked as completed with strikethrough text and 50% opacity (200ms ease transition), and localStorage is updated. Clicking again toggles it back to active.
- Given a todo exists, When the user clicks the delete button, Then the todo is immediately removed from the visible list and an undo snackbar appears for 4 seconds displaying 'Task deleted. Undo.' If the user clicks Undo, the todo is restored to its original position. If the timer expires, the deletion is finalized to localStorage and the todo_deleted tracking event fires.
- Given both active and completed todos exist, When the user selects a filter (All / Active / Completed), Then only matching todos are displayed. If the filtered result is empty, a contextual empty-state message is shown (e.g., 'No completed tasks.'). Adding a new todo while on the Completed filter auto-switches the filter to All.
- Given todos exist in localStorage, When the user refreshes the browser or navigates away and returns to /todo, Then all todos are restored with correct completed state and sort order from the versioned localStorage schema. If stored data is corrupted or unparseable, the app falls back to an empty list without crashing.
- Given localStorage is unavailable (private browsing, quota exceeded, or disabled), When the user performs any mutation, Then the app continues to function in-memory without crashing, and a non-blocking warning banner is displayed: 'Your browser storage is full or unavailable. Changes won't be saved.'
- Given the todo list is rendered, Then all interactive elements are keyboard-operable, checkboxes are real input elements with associated labels, delete buttons are button elements with aria-label including the task title, filter controls use role='radiogroup' with role='radio' children, the item count uses aria-live='polite', the list uses semantic ul/li structure, and all touch targets are at least 44x44px.
- Given completed todos exist, When the user clicks the 'Clear completed' button, Then all completed todos are removed from the list with an undo snackbar, and the button is only visible when completed todos are present.

## Implementation Details
### Architecture


# Technical Architecture Review: Todo Feature

## Data Model

```typescript
// src/app/features/todo/todo.model.ts
export interface Todo {
  id: string;          // UUID v4 — avoid numeric auto-increment to prevent collision on rapid adds
  title: string;
  completed: boolean;
  createdAt: string;   // ISO 8601 string — serializes cleanly to/from JSON in localStorage
}

export type TodoFilter = 'all' | 'active' | 'completed';

// Tracking event payloads — define these now so the analytics hook is typed from day one
export interface TodoTrackingEvent {
  eventName: 'todo_added' | 'todo_comple

### Developer Notes
**State Management & Service Design**
- Use Angular signals (`signal`, `computed`) — not RxJS — for all state in `TodoService`. Signals are the right tool for synchronous, local-only state.
- `TodoService` must be `providedIn: 'root'` (singleton) so state survives in-app route navigation without re-reading localStorage on every visit.
- Generate `id` via `crypto.randomUUID()`. Add a comment noting it requires a secure context (HTTPS or localhost). If plain HTTP support is ever needed, fall back to `Date.now().toString(36) + Math.random().toString(36).substring(2)`.
- Use `string` (ISO 8601) fo

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/e2e/todo.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/playwright.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.extra.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.extra.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=create a todo feature for this app (no backend, super simple) -->
<!-- bmad:team_id=SAM1 -->