### PR TITLE
feat(SAM1): Create a simple to-do feature for the app (no backend, super [SAM1-269]

### DIFF
--- a/e2e/todo.spec.ts
+++ b/e2e/todo.spec.ts
@@ -1,0 +1,265 @@
+import { test, expect } from '@playwright/test';
+
+const TODO_URL = '/todo';
+const STORAGE_KEY = 'todo_tasks';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(TODO_URL);
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.goto(TODO_URL);
+});
+
+test.describe('Todo Feature', () => {
+
+  test('shows empty state when no tasks exist', async ({ page }) => {
+    await expect(page.getByText('No tasks yet — add one above!')).toBeVisible();
+  });
+
+  test('input is auto-focused on load', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await expect(input).toBeFocused();
+  });
+
+  test('add a task via click', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Buy groceries');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    // Task appears in list
+    await expect(page.getByText('Buy groceries')).toBeVisible();
+    // Input is cleared
+    await expect(input).toHaveValue('');
+    // Focus remains on input
+    await expect(input).toBeFocused();
+    // Empty state gone
+    await expect(page.getByText('No tasks yet')).not.toBeVisible();
+  });
+
+  test('add a task via Enter key', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Walk the dog');
+    await input.press('Enter');
+
+    await expect(page.getByText('Walk the dog')).toBeVisible();
+    await expect(input).toHaveValue('');
+    await expect(input).toBeFocused();
+  });
+
+  test('trims whitespace from task text', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('  Clean house  ');
+    await input.press('Enter');
+
+    await expect(page.getByText('Clean house')).toBeVisible();
+  });
+
+  test('blocks empty input with validation hint', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    await expect(page.getByText('Enter a task description first.')).toBeVisible();
+    // No task added
+    await expect(page.getByText('No tasks yet — add one above!')).toBeVisible();
+  });
+
+  test('blocks whitespace-only input', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('   ');
+    await input.press('Enter');
+
+    await expect(page.getByText('Enter a task description first.')).toBeVisible();
+  });
+
+  test('validation hint clears on next keystroke', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Enter a task description first.')).toBeVisible();
+
+    const input = page.getByLabel('Task description');
+    await input.pressSequentially('a');
+
+    await expect(page.getByText('Enter a task description first.')).not.toBeVisible();
+  });
+
+  test('toggle task complete and back', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Test task');
+    await input.press('Enter');
+
+    const checkbox = page.getByRole('checkbox', { name: /Mark task: Test task/ });
+    await expect(checkbox).not.toBeChecked();
+
+    // Complete
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+
+    // The task row should have completed styling (strikethrough via class)
+    const taskRow = page.locator('.task-row.completed');
+    await expect(taskRow).toBeVisible();
+
+    // Uncomplete
+    await checkbox.uncheck();
+    await expect(checkbox).not.toBeChecked();
+    await expect(taskRow).not.toBeVisible();
+  });
+
+  test('delete task removes it and shows empty state', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Delete me');
+    await input.press('Enter');
+
+    await page.getByRole('button', { name: 'Delete task: Delete me' }).click();
+
+    await expect(page.getByText('Delete me')).not.toBeVisible();
+    await expect(page.getByText('No tasks yet — add one above!')).toBeVisible();
+    // Focus moves to input when list is empty
+    await expect(input).toBeFocused();
+  });
+
+  test('delete task moves focus to next task', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Task A');
+    await input.press('Enter');
+    await input.fill('Task B');
+    await input.press('Enter');
+
+    // Delete first task
+    await page.getByRole('button', { name: 'Delete task: Task A' }).click();
+
+    await expect(page.getByText('Task A')).not.toBeVisible();
+    await expect(page.getByText('Task B')).toBeVisible();
+    // Focus should be on remaining delete button
+    await expect(page.getByRole('button', { name: 'Delete task: Task B' })).toBeFocused();
+  });
+
+  test('tasks persist across page refresh', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('Persistent task');
+    await input.press('Enter');
+
+    // Toggle complete
+    await page.getByRole('checkbox', { name: /Mark task: Persistent task/ }).check();
+
+    // Refresh
+    await page.reload();
+
+    // Task still there and completed
+    await expect(page.getByText('Persistent task')).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: /Mark task: Persistent task/ })).toBeChecked();
+  });
+
+  test('corrupted localStorage gracefully falls back to empty list', async ({ page }) => {
+    await page.evaluate((key) => {
+      localStorage.setItem(key, 'not valid json{{{');
+    }, STORAGE_KEY);
+
+    await page.reload();
+
+    await expect(page.getByText('No tasks yet — add one above!')).toBeVisible();
+  });
+
+  test('multiple tasks maintain order and do not re-sort on toggle', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('First');
+    await input.press('Enter');
+    await input.fill('Second');
+    await input.press('Enter');
+    await input.fill('Third');
+    await input.press('Enter');
+
+    // Complete the first task
+    await page.getByRole('checkbox', { name: /Mark task: First/ }).check();
+
+    // Verify order is preserved (First still before Second)
+    const texts = await page.locator('.task-text').allTextContents();
+    expect(texts).toEqual(['First', 'Second', 'Third']);
+  });
+
+  test('responsive layout stacks vertically at 480px', async ({ page }) => {
+    await page.setViewportSize({ width: 480, height: 800 });
+    await page.goto(TODO_URL);
+
+    // The form should still be functional
+    const input = page.getByLabel('Task description');
+    await input.fill('Mobile task');
+    await input.press('Enter');
+    await expect(page.getByText('Mobile task')).toBeVisible();
+
+    // No horizontal overflow
+    const hasOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasOverflow).toBe(false);
+  });
+
+  test('responsive layout at 320px with no horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await page.goto(TODO_URL);
+
+    const input = page.getByLabel('Task description');
+    await input.fill('Narrow task');
+    await input.press('Enter');
+    await expect(page.getByText('Narrow task')).toBeVisible();
+
+    const hasOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasOverflow).toBe(false);
+  });
+
+  test('keyboard accessibility: Tab to Add, Space on checkbox, Enter on delete', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    await input.fill('KB task');
+    await input.press('Enter');
+
+    // Tab from input to Add button
+    await input.press('Tab');
+    await expect(page.getByRole('button', { name: 'Add' })).toBeFocused();
+
+    // Tab to checkbox
+    await page.keyboard.press('Tab');
+    const checkbox = page.getByRole('checkbox', { name: /Mark task: KB task/ });
+    await expect(checkbox).toBeFocused();
+
+    // Space toggles checkbox
+    await page.keyboard.press('Space');
+    await expect(checkbox).toBeChecked();
+
+    // Tab to delete button
+    await page.keyboard.press('Tab');
+    const deleteBtn = page.getByRole('button', { name: 'Delete task: KB task' });
+    await expect(deleteBtn).toBeFocused();
+
+    // Enter activates delete
+    await page.keyboard.press('Enter');
+    await expect(page.getByText('KB task')).not.toBeVisible();
+  });
+
+  test('ARIA attributes are present', async ({ page }) => {
+    // aria-live on empty state
+    const emptyState = page.getByText('No tasks yet — add one above!');
+    await expect(emptyState).toHaveAttribute('aria-live', 'polite');
+
+    // role="list" on task container (empty list is hidden, so check it's attached)
+    await expect(page.locator('[role="list"]')).toBeAttached();
+
+    // Add a task and check delete button aria-label
+    const input = page.getByLabel('Task description');
+    await input.fill('ARIA test');
+    await input.press('Enter');
+
+    await expect(page.getByRole('button', { name: 'Delete task: ARIA test' })).toBeVisible();
+  });
+
+  test('long text wraps without overflow', async ({ page }) => {
+    const input = page.getByLabel('Task description');
+    const longText = 'A'.repeat(200);
+    await input.fill(longText);
+    await input.press('Enter');
+
+    await expect(page.getByText(longText)).toBeVisible();
+
+    const hasOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasOverflow).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:e2e": "playwright test"
   },
   "private": true,
   "packageManager": "npm@11.6.2",
@@ -24,6 +25,7 @@
     "@angular/build": "^21.2.0",
     "@angular/cli": "^21.2.0",
     "@angular/compiler-cli": "^21.2.0",
+    "@playwright/test": "^1.58.2",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4200',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: 'npx ng serve --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { routes } from './app.routes';
+
+describe('App Routes', () => {
+  it('should have a lazy-loaded /todo route', () => {
+    const todoRoute = routes.find(r => r.path === 'todo');
+    expect(todoRoute).toBeTruthy();
+    expect(todoRoute!.loadComponent).toBeDefined();
+    expect(typeof todoRoute!.loadComponent).toBe('function');
+  });
+
+  it('should lazy-load TodoListComponent', async () => {
+    const todoRoute = routes.find(r => r.path === 'todo')!;
+    const mod = await (todoRoute.loadComponent as Function)();
+    expect(mod).toBeDefined();
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'todo',
+    loadComponent: () =>
+      import('./features/todo/todo-list.component').then(m => m.TodoListComponent),
+  },
+];

--- a/src/app/features/todo/todo-analytics.service.spec.ts
+++ b/src/app/features/todo/todo-analytics.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoAnalyticsService } from './todo-analytics.service';
+
+describe('TodoAnalyticsService', () => {
+  let service: TodoAnalyticsService;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TodoAnalyticsService);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('trackPageViewed logs todo_page_viewed with timestamp', () => {
+    service.trackPageViewed();
+    expect(logSpy).toHaveBeenCalledWith('todo_page_viewed', expect.objectContaining({ timestamp: expect.any(Number) }));
+  });
+
+  it('trackTaskAdded logs event with taskText and totalTasks', () => {
+    service.trackTaskAdded('Buy milk', 3);
+    expect(logSpy).toHaveBeenCalledWith('todo_task_added', expect.objectContaining({ taskText: 'Buy milk', totalTasks: 3 }));
+  });
+
+  it('trackTaskCompleted logs event with taskId and totalCompleted', () => {
+    service.trackTaskCompleted('abc', 2);
+    expect(logSpy).toHaveBeenCalledWith('todo_task_completed', expect.objectContaining({ taskId: 'abc', totalCompleted: 2 }));
+  });
+
+  it('trackTaskDeleted logs event with taskId and remainingTasks', () => {
+    service.trackTaskDeleted('xyz', 5);
+    expect(logSpy).toHaveBeenCalledWith('todo_task_deleted', expect.objectContaining({ taskId: 'xyz', remainingTasks: 5 }));
+  });
+
+  it('trackAddBlocked logs event with reason', () => {
+    service.trackAddBlocked('empty_input');
+    expect(logSpy).toHaveBeenCalledWith('todo_add_blocked', expect.objectContaining({ reason: 'empty_input' }));
+  });
+});

--- a/src/app/features/todo/todo-analytics.service.ts
+++ b/src/app/features/todo/todo-analytics.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Analytics abstraction for the todo feature.
+ * v1 implementation logs structured objects to console.
+ * Replace the console calls with a real analytics provider when available.
+ */
+@Injectable({ providedIn: 'root' })
+export class TodoAnalyticsService {
+  trackPageViewed(): void {
+    console.log('todo_page_viewed', { timestamp: Date.now() });
+  }
+
+  trackTaskAdded(taskText: string, totalTasks: number): void {
+    console.log('todo_task_added', { taskText, totalTasks, timestamp: Date.now() });
+  }
+
+  trackTaskCompleted(taskId: string, totalCompleted: number): void {
+    console.log('todo_task_completed', { taskId, totalCompleted, timestamp: Date.now() });
+  }
+
+  trackTaskDeleted(taskId: string, remainingTasks: number): void {
+    console.log('todo_task_deleted', { taskId, remainingTasks, timestamp: Date.now() });
+  }
+
+  trackAddBlocked(reason: string): void {
+    console.log('todo_add_blocked', { reason, timestamp: Date.now() });
+  }
+}

--- a/src/app/features/todo/todo-list.component.spec.ts
+++ b/src/app/features/todo/todo-list.component.spec.ts
@@ -1,0 +1,423 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TodoListComponent } from './todo-list.component';
+import { TodoStorageService } from './todo-storage.service';
+import { TodoAnalyticsService } from './todo-analytics.service';
+import { TodoTask } from './todo.model';
+
+describe('TodoListComponent', () => {
+  let fixture: ComponentFixture<TodoListComponent>;
+  let component: TodoListComponent;
+  let storageSpy: { load: ReturnType<typeof vi.fn>; save: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
+  let analyticsSpy: {
+    trackPageViewed: ReturnType<typeof vi.fn>;
+    trackTaskAdded: ReturnType<typeof vi.fn>;
+    trackTaskCompleted: ReturnType<typeof vi.fn>;
+    trackTaskDeleted: ReturnType<typeof vi.fn>;
+    trackAddBlocked: ReturnType<typeof vi.fn>;
+  };
+
+  const sampleTasks: TodoTask[] = [
+    { id: '1', text: 'Buy milk', completed: false, createdAt: 1000 },
+    { id: '2', text: 'Walk dog', completed: true, createdAt: 2000 },
+  ];
+
+  beforeEach(async () => {
+    storageSpy = {
+      load: vi.fn().mockReturnValue([]),
+      save: vi.fn(),
+      clear: vi.fn(),
+    } as any;
+
+    analyticsSpy = {
+      trackPageViewed: vi.fn(),
+      trackTaskAdded: vi.fn(),
+      trackTaskCompleted: vi.fn(),
+      trackTaskDeleted: vi.fn(),
+      trackAddBlocked: vi.fn(),
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+    })
+      .overrideProvider(TodoStorageService, { useValue: storageSpy })
+      .overrideProvider(TodoAnalyticsService, { useValue: analyticsSpy })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+  });
+
+  // === INIT & PAGE VIEWED ===
+
+  it('should create and track page viewed', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+    expect(analyticsSpy.trackPageViewed).toHaveBeenCalled();
+  });
+
+  it('should load tasks from storage on init', () => {
+    storageSpy.load.mockReturnValue([...sampleTasks]);
+    fixture.detectChanges();
+    expect(component.tasks().length).toBe(2);
+  });
+
+  // === EMPTY STATE ===
+
+  it('should show empty state when no tasks', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('.empty-state');
+    expect(el).toBeTruthy();
+    expect(el!.textContent).toContain('No tasks yet');
+    expect(el!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('should hide empty state when tasks exist', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'X', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeFalsy();
+  });
+
+  // === ADD TASK ===
+
+  it('should add a task with trimmed text and clear input', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = '  New task  ';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(1);
+    expect(component.tasks()[0].text).toBe('New task');
+    expect(component.tasks()[0].completed).toBe(false);
+    expect(component.tasks()[0].id).toBeTruthy();
+    expect(component.inputValue()).toBe('');
+    expect(storageSpy.save).toHaveBeenCalled();
+    expect(analyticsSpy.trackTaskAdded).toHaveBeenCalledWith('New task', 1);
+  });
+
+  it('should add task at the bottom of the list', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'First', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = 'Second';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(2);
+    expect(component.tasks()[1].text).toBe('Second');
+  });
+
+  it('should allow duplicate task text', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = 'Same task';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+
+    input.value = 'Same task';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(2);
+    expect(component.tasks()[0].id).not.toBe(component.tasks()[1].id);
+  });
+
+  it('should hide empty state after adding a task', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeTruthy();
+
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+    input.value = 'Task';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeFalsy();
+  });
+
+  // === VALIDATION ===
+
+  it('should reject empty input and show validation hint', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = '   ';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(0);
+    const hint = fixture.nativeElement.querySelector('.validation-hint');
+    expect(hint).toBeTruthy();
+    expect(hint!.textContent).toContain('Enter a task description first.');
+    expect(analyticsSpy.trackAddBlocked).toHaveBeenCalledWith('empty_input');
+  });
+
+  it('should reject completely empty input', () => {
+    fixture.detectChanges();
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(0);
+    expect(component.showHint()).toBe(true);
+  });
+
+  it('should clear validation hint on next input', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.validation-hint')).toBeTruthy();
+
+    input.value = 'a';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.validation-hint')).toBeFalsy();
+  });
+
+  it('should not show validation hint initially', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.validation-hint')).toBeFalsy();
+  });
+
+  // === TOGGLE COMPLETE ===
+
+  it('should toggle task completion', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Test', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.click();
+    fixture.detectChanges();
+
+    expect(component.tasks()[0].completed).toBe(true);
+    expect(storageSpy.save).toHaveBeenCalled();
+    expect(analyticsSpy.trackTaskCompleted).toHaveBeenCalled();
+
+    // Toggle back
+    checkbox.click();
+    fixture.detectChanges();
+    expect(component.tasks()[0].completed).toBe(false);
+  });
+
+  it('should not re-sort tasks when toggling completion', () => {
+    storageSpy.load.mockReturnValue([
+      { id: '1', text: 'A', completed: false, createdAt: 1 },
+      { id: '2', text: 'B', completed: false, createdAt: 2 },
+      { id: '3', text: 'C', completed: false, createdAt: 3 },
+    ]);
+    fixture.detectChanges();
+
+    const checkboxes = fixture.nativeElement.querySelectorAll('input[type="checkbox"]');
+    checkboxes[1].click(); // complete middle task
+    fixture.detectChanges();
+
+    expect(component.tasks()[0].id).toBe('1');
+    expect(component.tasks()[1].id).toBe('2');
+    expect(component.tasks()[2].id).toBe('3');
+  });
+
+  it('should apply completed styling class', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Done', completed: true, createdAt: 1 }]);
+    fixture.detectChanges();
+    const row = fixture.nativeElement.querySelector('.task-row');
+    expect(row.classList.contains('completed')).toBe(true);
+  });
+
+  it('should remove completed styling when toggled back', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Done', completed: true, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+    checkbox.click();
+    fixture.detectChanges();
+
+    const row = fixture.nativeElement.querySelector('.task-row');
+    expect(row.classList.contains('completed')).toBe(false);
+  });
+
+  it('should compute completedCount correctly', () => {
+    storageSpy.load.mockReturnValue([...sampleTasks]);
+    fixture.detectChanges();
+    expect(component.completedCount()).toBe(1);
+  });
+
+  // === DELETE TASK ===
+
+  it('should delete a task', async () => {
+    storageSpy.load.mockReturnValue([
+      { id: '1', text: 'A', completed: false, createdAt: 1 },
+      { id: '2', text: 'B', completed: false, createdAt: 2 },
+    ]);
+    fixture.detectChanges();
+
+    const deleteBtns = fixture.nativeElement.querySelectorAll('.delete-btn');
+    deleteBtns[0].click();
+    await new Promise(resolve => setTimeout(resolve));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(1);
+    expect(component.tasks()[0].id).toBe('2');
+    expect(storageSpy.save).toHaveBeenCalled();
+    expect(analyticsSpy.trackTaskDeleted).toHaveBeenCalledWith('1', 1);
+  });
+
+  it('should show empty state after deleting last task', async () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Only', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    const deleteBtn = fixture.nativeElement.querySelector('.delete-btn');
+    deleteBtn.click();
+    await new Promise(resolve => setTimeout(resolve));
+    fixture.detectChanges();
+
+    expect(component.tasks().length).toBe(0);
+    const empty = fixture.nativeElement.querySelector('.empty-state');
+    expect(empty).toBeTruthy();
+  });
+
+  it('should focus input after deleting last task', async () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Only', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    const deleteBtn = fixture.nativeElement.querySelector('.delete-btn');
+    deleteBtn.click();
+    await new Promise(resolve => setTimeout(resolve));
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input[type="text"]');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('should focus next delete button after deleting a task with remaining tasks', async () => {
+    storageSpy.load.mockReturnValue([
+      { id: '1', text: 'A', completed: false, createdAt: 1 },
+      { id: '2', text: 'B', completed: false, createdAt: 2 },
+      { id: '3', text: 'C', completed: false, createdAt: 3 },
+    ]);
+    fixture.detectChanges();
+
+    const deleteBtns = fixture.nativeElement.querySelectorAll('.delete-btn');
+    deleteBtns[0].click();
+    await new Promise(resolve => setTimeout(resolve));
+    fixture.detectChanges();
+
+    // After deleting first, focus should be on the new first delete button
+    const remainingBtns = fixture.nativeElement.querySelectorAll('.delete-btn');
+    expect(document.activeElement).toBe(remainingBtns[0]);
+  });
+
+  // === PERSISTENCE ===
+
+  it('should save to storage on every add', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const form = fixture.nativeElement.querySelector('form');
+
+    input.value = 'Task 1';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+
+    expect(storageSpy.save).toHaveBeenCalledTimes(1);
+    expect(storageSpy.save).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ text: 'Task 1' })]));
+  });
+
+  it('should save to storage on toggle', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'X', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('input[type="checkbox"]').click();
+    fixture.detectChanges();
+
+    expect(storageSpy.save).toHaveBeenCalledWith([expect.objectContaining({ id: '1', completed: true })]);
+  });
+
+  it('should save to storage on delete', async () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'X', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.delete-btn').click();
+    fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(storageSpy.save).toHaveBeenCalledWith([]);
+  });
+
+  // === ACCESSIBILITY ===
+
+  it('should have aria-label on delete buttons', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Groceries', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('.delete-btn');
+    expect(btn.getAttribute('aria-label')).toBe('Delete task: Groceries');
+  });
+
+  it('should have aria-label on checkboxes', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'Groceries', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+    expect(checkbox.getAttribute('aria-label')).toBe('Mark task: Groceries');
+  });
+
+  it('should have role=list on task container', () => {
+    fixture.detectChanges();
+    const list = fixture.nativeElement.querySelector('[role="list"]');
+    expect(list).toBeTruthy();
+  });
+
+  it('should have role=listitem on task rows', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'X', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('[role="listitem"]');
+    expect(item).toBeTruthy();
+  });
+
+  it('should have maxlength 200 on input', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]');
+    expect(input.getAttribute('maxlength')).toBe('200');
+  });
+
+  it('should auto-focus input on load', () => {
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="text"]');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('should use real checkbox and button elements', () => {
+    storageSpy.load.mockReturnValue([{ id: '1', text: 'X', completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('input[type="checkbox"]').tagName).toBe('INPUT');
+    expect(fixture.nativeElement.querySelector('.delete-btn').tagName).toBe('BUTTON');
+  });
+
+  it('should display header "My To-Dos"', () => {
+    fixture.detectChanges();
+    const h1 = fixture.nativeElement.querySelector('h1');
+    expect(h1.textContent).toContain('My To-Dos');
+  });
+
+  it('should display task text with overflow-wrap', () => {
+    const longText = 'a'.repeat(200);
+    storageSpy.load.mockReturnValue([{ id: '1', text: longText, completed: false, createdAt: 1 }]);
+    fixture.detectChanges();
+    const textEl = fixture.nativeElement.querySelector('.task-text');
+    expect(textEl.textContent).toContain(longText);
+  });
+});

--- a/src/app/features/todo/todo-list.component.ts
+++ b/src/app/features/todo/todo-list.component.ts
@@ -1,0 +1,284 @@
+import {
+  Component,
+  OnInit,
+  signal,
+  computed,
+  ViewChildren,
+  QueryList,
+  ElementRef,
+  ViewChild,
+  AfterViewInit,
+} from '@angular/core';
+import { TodoTask } from './todo.model';
+import { TodoStorageService } from './todo-storage.service';
+import { TodoAnalyticsService } from './todo-analytics.service';
+
+function generateId(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return Date.now().toString(36) + Math.random().toString(36).slice(2);
+  }
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-todo-list',
+  template: `
+    <div class="todo-card">
+      <h1>My To-Dos</h1>
+
+      <form class="input-row" (submit)="onSubmit($event)">
+        <input
+          #taskInput
+          type="text"
+          [value]="inputValue()"
+          (input)="onInputChange($event)"
+          placeholder="What do you need to do?"
+          maxlength="200"
+          aria-label="Task description"
+        />
+        <button type="submit">Add</button>
+      </form>
+
+      @if (showHint()) {
+        <p class="validation-hint">Enter a task description first.</p>
+      }
+
+      @if (tasks().length === 0) {
+        <p class="empty-state" aria-live="polite">No tasks yet — add one above!</p>
+      }
+
+      <div role="list" class="task-list">
+        @for (task of tasks(); track task.id; let i = $index) {
+          <div role="listitem" class="task-row" [class.completed]="task.completed">
+            <input
+              type="checkbox"
+              [checked]="task.completed"
+              (change)="toggleComplete(task.id)"
+              [attr.aria-label]="'Mark task: ' + task.text"
+            />
+            <span class="task-text">{{ task.text }}</span>
+            <button
+              #deleteBtn
+              class="delete-btn"
+              (click)="deleteTask(task.id, i)"
+              [attr.aria-label]="'Delete task: ' + task.text"
+            >Delete</button>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: flex;
+      justify-content: center;
+      padding: 1rem;
+      box-sizing: border-box;
+    }
+
+    .todo-card {
+      width: 100%;
+      max-width: 600px;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      padding: 1.5rem;
+    }
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: 1.5rem;
+    }
+
+    .input-row {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .input-row input[type="text"] {
+      flex: 1;
+      padding: 0.5rem 0.75rem;
+      font-size: 1rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      min-width: 0;
+    }
+
+    .input-row button {
+      padding: 0.5rem 1.25rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 4px;
+      background: #4a90d9;
+      color: #fff;
+      cursor: pointer;
+      min-height: 44px;
+      min-width: 44px;
+    }
+
+    .input-row button:hover {
+      background: #357abd;
+    }
+
+    .validation-hint {
+      margin: 0.25rem 0 0;
+      font-size: 0.875rem;
+      color: #888;
+    }
+
+    .empty-state {
+      text-align: center;
+      color: #888;
+      padding: 2rem 0;
+    }
+
+    .task-list {
+      margin-top: 1rem;
+    }
+
+    .task-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #eee;
+    }
+
+    .task-row input[type="checkbox"] {
+      margin-top: 0.25rem;
+      min-width: 20px;
+      min-height: 20px;
+      cursor: pointer;
+    }
+
+    .task-text {
+      flex: 1;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      min-width: 0;
+    }
+
+    .task-row.completed .task-text {
+      text-decoration: line-through;
+      opacity: 0.6;
+    }
+
+    .delete-btn {
+      min-width: 44px;
+      min-height: 44px;
+      border: none;
+      border-radius: 4px;
+      background: #e74c3c;
+      color: #fff;
+      cursor: pointer;
+      font-size: 0.875rem;
+      flex-shrink: 0;
+    }
+
+    .delete-btn:hover {
+      background: #c0392b;
+    }
+
+    @media (max-width: 480px) {
+      .input-row {
+        flex-direction: column;
+      }
+
+      .input-row button {
+        width: 100%;
+      }
+    }
+  `],
+})
+export class TodoListComponent implements OnInit, AfterViewInit {
+  tasks = signal<TodoTask[]>([]);
+  inputValue = signal('');
+  showHint = signal(false);
+  completedCount = computed(() => this.tasks().filter(t => t.completed).length);
+
+  @ViewChild('taskInput') taskInputRef!: ElementRef<HTMLInputElement>;
+  @ViewChildren('deleteBtn') deleteBtns!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  constructor(
+    private storage: TodoStorageService,
+    private analytics: TodoAnalyticsService,
+  ) {}
+
+  ngOnInit(): void {
+    this.tasks.set(this.storage.load());
+    this.analytics.trackPageViewed();
+  }
+
+  ngAfterViewInit(): void {
+    this.taskInputRef?.nativeElement.focus();
+  }
+
+  onInputChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.inputValue.set(value);
+    if (this.showHint()) {
+      this.showHint.set(false);
+    }
+  }
+
+  onSubmit(event: Event): void {
+    event.preventDefault();
+    const text = this.inputValue().trim();
+    if (!text) {
+      this.showHint.set(true);
+      this.analytics.trackAddBlocked('empty_input');
+      return;
+    }
+
+    const task: TodoTask = {
+      id: generateId(),
+      text,
+      completed: false,
+      createdAt: Date.now(),
+    };
+
+    this.tasks.update(tasks => [...tasks, task]);
+    this.inputValue.set('');
+    // Clear the actual input element value
+    if (this.taskInputRef) {
+      this.taskInputRef.nativeElement.value = '';
+    }
+    this.storage.save(this.tasks());
+    this.analytics.trackTaskAdded(text, this.tasks().length);
+    this.showHint.set(false);
+
+    // Retain focus on input for rapid entry
+    this.taskInputRef?.nativeElement.focus();
+  }
+
+  toggleComplete(id: string): void {
+    this.tasks.update(tasks =>
+      tasks.map(t => t.id === id ? { ...t, completed: !t.completed } : t)
+    );
+    this.storage.save(this.tasks());
+    const toggledTask = this.tasks().find(t => t.id === id);
+    if (toggledTask?.completed) {
+      this.analytics.trackTaskCompleted(id, this.completedCount());
+    }
+  }
+
+  deleteTask(id: string, index: number): void {
+    // TODO: undo toast — fast follow
+    this.tasks.update(tasks => tasks.filter(t => t.id !== id));
+    this.storage.save(this.tasks());
+    this.analytics.trackTaskDeleted(id, this.tasks().length);
+
+    // Focus management: move to next task's delete button, or input if empty
+    setTimeout(() => {
+      const btns = this.deleteBtns?.toArray();
+      if (btns && btns.length > 0) {
+        const nextIndex = Math.min(index, btns.length - 1);
+        btns[nextIndex].nativeElement.focus();
+      } else {
+        this.taskInputRef?.nativeElement.focus();
+      }
+    });
+  }
+}

--- a/src/app/features/todo/todo-storage.service.spec.ts
+++ b/src/app/features/todo/todo-storage.service.spec.ts
@@ -1,0 +1,130 @@
+import { TestBed } from '@angular/core/testing';
+import { TodoStorageService } from './todo-storage.service';
+import { TodoTask } from './todo.model';
+
+describe('TodoStorageService', () => {
+  let service: TodoStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TodoStorageService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  const makeTasks = (): TodoTask[] => [
+    { id: 'a', text: 'Task A', completed: false, createdAt: 1000 },
+    { id: 'b', text: 'Task B', completed: true, createdAt: 2000 },
+  ];
+
+  it('should return empty array when localStorage is empty', () => {
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should round-trip save and load tasks in versioned envelope', () => {
+    const tasks = makeTasks();
+    service.save(tasks);
+    expect(service.load()).toEqual(tasks);
+  });
+
+  it('should return empty array for corrupted JSON', () => {
+    localStorage.setItem('todo_tasks', '{bad json');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(service.load()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should return empty array for non-array tasks field', () => {
+    localStorage.setItem('todo_tasks', JSON.stringify({ version: 1, tasks: 'not-an-array' }));
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should return empty array for object without version field', () => {
+    localStorage.setItem('todo_tasks', JSON.stringify({ tasks: [] }));
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should return empty array for null stored value parsed as string', () => {
+    localStorage.setItem('todo_tasks', 'null');
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should return empty array for number stored value', () => {
+    localStorage.setItem('todo_tasks', '42');
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should return empty array for string stored value', () => {
+    localStorage.setItem('todo_tasks', '"hello"');
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should handle plain array fallback (legacy format)', () => {
+    const tasks = makeTasks();
+    localStorage.setItem('todo_tasks', JSON.stringify(tasks));
+    expect(service.load()).toEqual(tasks);
+  });
+
+  it('should store data as versioned envelope with version 1', () => {
+    service.save(makeTasks());
+    const raw = JSON.parse(localStorage.getItem('todo_tasks')!);
+    expect(raw.version).toBe(1);
+    expect(Array.isArray(raw.tasks)).toBe(true);
+    expect(raw.tasks.length).toBe(2);
+  });
+
+  it('should save empty array correctly', () => {
+    service.save([]);
+    const raw = JSON.parse(localStorage.getItem('todo_tasks')!);
+    expect(raw.version).toBe(1);
+    expect(raw.tasks).toEqual([]);
+  });
+
+  it('should clear stored data', () => {
+    service.save(makeTasks());
+    service.clear();
+    expect(localStorage.getItem('todo_tasks')).toBeNull();
+    expect(service.load()).toEqual([]);
+  });
+
+  it('should handle QuotaExceededError on save gracefully', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => service.save(makeTasks())).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+    spy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('should handle localStorage.getItem throwing', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(service.load()).toEqual([]);
+    spy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('should handle localStorage.removeItem throwing on clear', () => {
+    const spy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(() => service.clear()).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it('should preserve task completed state through round-trip', () => {
+    const tasks = makeTasks();
+    service.save(tasks);
+    const loaded = service.load();
+    expect(loaded[0].completed).toBe(false);
+    expect(loaded[1].completed).toBe(true);
+  });
+});

--- a/src/app/features/todo/todo-storage.service.ts
+++ b/src/app/features/todo/todo-storage.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { TodoTask, TodoStorageEnvelope } from './todo.model';
+
+// NOTE: localStorage key is not namespaced; update if an app-wide prefix convention is established.
+const STORAGE_KEY = 'todo_tasks';
+const CURRENT_VERSION = 1;
+
+@Injectable({ providedIn: 'root' })
+export class TodoStorageService {
+  load(): TodoTask[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw === null) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+
+      // Support versioned envelope
+      if (parsed && typeof parsed === 'object' && typeof parsed.version === 'number' && Array.isArray(parsed.tasks)) {
+        return parsed.tasks;
+      }
+
+      // Fallback: if somehow stored as plain array (shouldn't happen but defensive)
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+
+      return [];
+    } catch {
+      console.warn('TodoStorageService: failed to load tasks from localStorage, returning empty list.');
+      return [];
+    }
+  }
+
+  save(tasks: TodoTask[]): void {
+    try {
+      const envelope: TodoStorageEnvelope = { version: CURRENT_VERSION, tasks };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(envelope));
+    } catch (e) {
+      console.warn('TodoStorageService: failed to save tasks to localStorage.', e);
+    }
+  }
+
+  clear(): void {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Silently ignore — localStorage may be unavailable
+    }
+  }
+}

--- a/src/app/features/todo/todo.model.ts
+++ b/src/app/features/todo/todo.model.ts
@@ -1,0 +1,11 @@
+export interface TodoTask {
+  id: string;
+  text: string;
+  completed: boolean;
+  createdAt: number;
+}
+
+export interface TodoStorageEnvelope {
+  version: number;
+  tasks: TodoTask[];
+}


### PR DESCRIPTION
## Story
**SAM1-269**: **Hypothesis**

## Acceptance Criteria
- Given the user is on /todo, when they type a non-empty task and click Add (or press Enter), then the trimmed task appears at the bottom of the list, the input clears, and focus remains on the input field
- Given the input is empty or contains only whitespace, when the user clicks Add or presses Enter, then no task is added and an inline validation hint appears below the input, clearing automatically on the next keystroke
- Given a task exists, when the user clicks the checkbox, then the task text shows strikethrough with reduced opacity and the completed state toggles; clicking again reverses it without re-sorting the list
- Given a task exists, when the user clicks the delete button, then the task is removed from the list, focus moves to the next task (or to the input if the list is now empty), and the empty state message reappears if no tasks remain
- Given tasks exist in the list, when the page is refreshed, then all tasks reload from localStorage with their correct completed state preserved; if localStorage is unavailable or contains corrupted data, the component initializes with an empty list without errors
- Given no tasks exist, when the user views the /todo page, then the empty-state message 'No tasks yet — add one above!' is displayed in an aria-live polite region
- Given viewport widths of 480px and 320px, when the page renders, then the input and button stack vertically, task text wraps without horizontal overflow, and all interactive tap targets meet the 44x44px minimum
- Given a keyboard-only user, when they navigate the /todo page, then the input is auto-focused on load, the Add button is reachable via Tab, checkboxes toggle via Space, delete buttons activate via Enter or Space, and all interactive elements have descriptive ARIA labels

## Implementation Details
### Architecture


# Technical Architecture Review: Todo List Feature

## Data Model

The feature is entirely client-side, so no backend schema changes are needed. Define a single interface for the task entity:

```typescript
// src/app/features/todo/todo.model.ts
export interface TodoTask {
  id: string;       // UUID v4 generated client-side
  text: string;     // trimmed, non-empty task description
  completed: boolean;
  createdAt: number; // epoch ms — supports future sorting/analytics
}
```

Use `crypto.randomUUID()` for ID generation — it's available in all modern browsers and avoids pulling in a librar

### Developer Notes
**File structure — all under `src/app/features/todo/`**
- `todo.model.ts` — `TodoTask` interface (`id`, `text`, `completed`, `createdAt`) and `TodoStorageEnvelope` interface (`{ version: number, tasks: TodoTask[] }`)
- `todo-storage.service.ts` — Injectable service wrapping all `localStorage` access; stores under key `todo_tasks` as a versioned envelope; `load()` validates parsed result with `Array.isArray()` guard and version check, returns `[]` on any failure; `save()` catches `QuotaExceededError` and logs warning; `clear()` for test cleanup
- `todo-analytics.service.ts` — Injectable service

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/e2e/todo.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/package.json`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/playwright.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-analytics.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-analytics.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-list.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-storage.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo-storage.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/todo/todo.model.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Create a simple to-do feature for the app (no backend, super simple) -->
<!-- bmad:team_id=SAM1 -->