### PR TITLE
feat(SAM1): Build a newsletter subscription form that allows users to en [SAM1-276]

### DIFF
--- a/e2e/newsletter.spec.ts
+++ b/e2e/newsletter.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = '**/api/newsletter/subscribe';
+
+test.beforeEach(async ({ page }) => {
+  // Navigate first to get access to localStorage, then clear it
+  await page.goto('/newsletter');
+  await page.evaluate(() => localStorage.clear());
+});
+
+test.describe('Newsletter Subscription', () => {
+  test('valid subscription shows success and sets localStorage', async ({ page }) => {
+    await page.route(API_URL, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+    );
+    await page.goto('/newsletter');
+
+    await page.getByLabel('Email address').fill('user@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    await expect(page.getByText("You're subscribed! Check your inbox for a welcome email.")).toBeVisible();
+    await expect(page.getByLabel('Email address')).not.toBeVisible();
+
+    const flag = await page.evaluate(() => localStorage.getItem('newsletter_subscribed'));
+    expect(flag).toBe('true');
+  });
+
+  test('empty submission shows required error', async ({ page }) => {
+    await page.goto('/newsletter');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    await expect(page.getByText('Please enter your email address.')).toBeVisible();
+  });
+
+  test('invalid email shows validation error', async ({ page }) => {
+    let apiCalled = false;
+    await page.route(API_URL, (route) => {
+      apiCalled = true;
+      route.fulfill({ status: 200, body: '{}' });
+    });
+
+    await page.goto('/newsletter');
+    await page.getByLabel('Email address').fill('not-an-email');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    await expect(page.getByText('Please enter a valid email address.')).toBeVisible();
+    expect(apiCalled).toBe(false);
+  });
+
+  test('duplicate email (409) shows inline error and preserves input', async ({ page }) => {
+    await page.route(API_URL, (route) =>
+      route.fulfill({ status: 409, contentType: 'application/json', body: JSON.stringify({}) })
+    );
+    await page.goto('/newsletter');
+
+    await page.getByLabel('Email address').fill('dupe@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    await expect(page.getByText('This email is already subscribed.')).toBeVisible();
+    await expect(page.getByLabel('Email address')).toHaveValue('dupe@example.com');
+  });
+
+  test('network error shows error message and preserves input', async ({ page }) => {
+    await page.route(API_URL, (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({}) })
+    );
+    await page.goto('/newsletter');
+
+    await page.getByLabel('Email address').fill('user@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    await expect(page.getByText('Something went wrong. Please try again.')).toBeVisible();
+    await expect(page.getByLabel('Email address')).toHaveValue('user@example.com');
+  });
+
+  test('double-submit is prevented with disabled button showing Subscribing…', async ({ page }) => {
+    await page.route(API_URL, async (route) => {
+      await new Promise((r) => setTimeout(r, 3000));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    });
+    await page.goto('/newsletter');
+
+    await page.getByLabel('Email address').fill('user@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    const button = page.getByRole('button', { name: /Subscribing/ });
+    await expect(button).toBeDisabled();
+  });
+
+  test('accessibility: errors use aria-describedby and success uses aria-live', async ({ page }) => {
+    await page.goto('/newsletter');
+
+    // Trigger error
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    // Wait for error to appear
+    await expect(page.getByText('Please enter your email address.')).toBeVisible();
+
+    // Check aria-describedby links input to error
+    const describedBy = await page.getByLabel('Email address').getAttribute('aria-describedby');
+    expect(describedBy).toBe('email-error');
+
+    // Check error element exists with role="alert"
+    const errorEl = page.locator('#email-error');
+    await expect(errorEl).toBeVisible();
+    await expect(errorEl).toHaveAttribute('role', 'alert');
+
+    // Now submit successfully and check aria-live
+    await page.route(API_URL, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+    );
+    await page.getByLabel('Email address').fill('user@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).click();
+
+    const successRegion = page.locator('[aria-live="polite"]').filter({ hasText: "You're subscribed!" });
+    await expect(successRegion).toBeVisible();
+  });
+
+  test('returning subscriber sees "already subscribed" message instead of form', async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem('newsletter_subscribed', 'true'));
+    await page.goto('/newsletter');
+
+    await expect(page.getByText("You're already subscribed!")).toBeVisible();
+    await expect(page.getByLabel('Email address')).not.toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:e2e": "playwright test"
   },
   "private": true,
   "packageManager": "npm@11.6.2",
@@ -24,6 +25,7 @@
     "@angular/build": "^21.2.0",
     "@angular/cli": "^21.2.0",
     "@angular/compiler-cli": "^21.2.0",
+    "@playwright/test": "^1.58.2",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4200',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: 'npx ng serve --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,13 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient(),
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,7 @@
 import { Routes } from '@angular/router';
+import { NewsletterComponent } from './features/newsletter/newsletter.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'newsletter', component: NewsletterComponent },
+  { path: '', redirectTo: 'newsletter', pathMatch: 'full' },
+];

--- a/src/app/features/newsletter/newsletter.component.css
+++ b/src/app/features/newsletter/newsletter.component.css
@@ -1,0 +1,166 @@
+.newsletter-container {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.newsletter-card {
+  max-width: 480px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.value-proposition {
+  color: #555;
+  margin: 0 0 1.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+label[for="email"] {
+  font-weight: 600;
+  margin-bottom: 0.375rem;
+}
+
+input#email {
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 2px solid #ccc;
+  border-radius: 6px;
+  min-height: 44px;
+  box-sizing: border-box;
+}
+
+input#email:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+  border-color: #0066cc;
+}
+
+input#email[aria-invalid="true"] {
+  border-color: #d32f2f;
+}
+
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  height: 0;
+  overflow: hidden;
+}
+
+.error-message {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-top: 0.375rem;
+}
+
+.subscribe-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  background-color: #0066cc;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.subscribe-button:hover:not(:disabled) {
+  background-color: #0052a3;
+}
+
+.subscribe-button:focus-visible {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+.subscribe-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.submitting-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.success-message {
+  padding: 1rem;
+  background-color: #e8f5e9;
+  border-radius: 6px;
+  color: #2e7d32;
+  font-weight: 500;
+}
+
+.already-subscribed-message {
+  padding: 1rem;
+  background-color: #e3f2fd;
+  border-radius: 6px;
+  color: #1565c0;
+  font-weight: 500;
+}
+
+.privacy-line {
+  font-size: 0.8125rem;
+  color: #777;
+  margin-top: 1rem;
+}
+
+.privacy-line a {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.privacy-line a:focus-visible {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+@media (min-width: 480px) {
+  form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .form-field {
+    flex: 1;
+    margin-bottom: 0;
+  }
+
+  .subscribe-button {
+    width: auto;
+    align-self: flex-end;
+  }
+}

--- a/src/app/features/newsletter/newsletter.component.html
+++ b/src/app/features/newsletter/newsletter.component.html
@@ -1,0 +1,81 @@
+<!-- Already subscribed state -->
+<div class="newsletter-container" *ngIf="formState === 'already-subscribed'">
+  <div class="newsletter-card" aria-live="polite">
+    <h1>Newsletter</h1>
+    <p class="already-subscribed-message">You're already subscribed!</p>
+  </div>
+</div>
+
+<!-- Success state -->
+<div class="newsletter-container" *ngIf="formState === 'success'">
+  <div class="newsletter-card">
+    <h1>Newsletter</h1>
+    <div aria-live="polite" class="success-message" role="status">
+      You're subscribed! Check your inbox for a welcome email.
+    </div>
+  </div>
+</div>
+
+<!-- Form state (idle, submitting, error) -->
+<div class="newsletter-container" *ngIf="formState !== 'success' && formState !== 'already-subscribed'">
+  <div class="newsletter-card">
+    <h1>Newsletter</h1>
+    <p class="value-proposition">Get the latest updates, tips, and exclusive content delivered to your inbox.</p>
+
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+      <div class="form-field">
+        <label for="email">Email address</label>
+        <input
+          id="email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          placeholder="you@example.com"
+          [attr.aria-describedby]="showEmailError && !serverError ? 'email-error' : serverError ? 'server-error' : null"
+          [attr.aria-invalid]="(showEmailError || serverError) ? true : null"
+        />
+
+        <!-- Honeypot field - visually hidden -->
+        <div class="honeypot" aria-hidden="true">
+          <label for="website">Website</label>
+          <input id="website" type="text" formControlName="website" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <div
+          id="email-error"
+          class="error-message"
+          role="alert"
+          *ngIf="showEmailError && !serverError"
+        >
+          <span aria-hidden="true">&#9888;</span> Error: {{ emailErrorMessage }}
+        </div>
+
+        <div
+          id="server-error"
+          class="error-message"
+          role="alert"
+          *ngIf="serverError"
+        >
+          <span aria-hidden="true">&#9888;</span> Error: {{ serverError }}
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        class="subscribe-button"
+        [disabled]="formState === 'submitting'"
+      >
+        <span *ngIf="formState !== 'submitting'">Subscribe</span>
+        <span *ngIf="formState === 'submitting'" class="submitting-label">
+          <span class="spinner" aria-hidden="true"></span>
+          Subscribing&hellip;
+        </span>
+      </button>
+    </form>
+
+    <p class="privacy-line">
+      We respect your privacy. Unsubscribe anytime.
+      <a routerLink="/privacy">Privacy Policy</a>
+    </p>
+  </div>
+</div>

--- a/src/app/features/newsletter/newsletter.component.spec.ts
+++ b/src/app/features/newsletter/newsletter.component.spec.ts
@@ -1,0 +1,184 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { NewsletterComponent } from './newsletter.component';
+import { NewsletterService } from './newsletter.service';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('NewsletterComponent', () => {
+  let component: NewsletterComponent;
+  let fixture: ComponentFixture<NewsletterComponent>;
+  let httpMock: HttpTestingController;
+  let service: NewsletterService;
+
+  function setup(isSubscribed = false) {
+    TestBed.configureTestingModule({
+      imports: [NewsletterComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    });
+
+    service = TestBed.inject(NewsletterService);
+    vi.spyOn(service, 'isSubscribed').mockReturnValue(isSubscribed);
+    vi.spyOn(service, 'setSubscribed').mockImplementation(() => {});
+
+    fixture = TestBed.createComponent(NewsletterComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  }
+
+  // AC1: Valid Subscription
+  it('should show success message and set localStorage on valid submission', () => {
+    setup();
+    component.form.get('email')!.setValue('user@example.com');
+    component.onSubmit();
+
+    expect(component.formState).toBe('submitting');
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.flush({});
+
+    expect(component.formState).toBe('success');
+    expect(service.setSubscribed).toHaveBeenCalled();
+
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.success-message')?.textContent).toContain("You're subscribed!");
+  });
+
+  // AC2: Empty Submission Blocked
+  it('should show error when email is empty', () => {
+    setup();
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.emailErrorMessage).toBe('Please enter your email address.');
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.error-message')?.textContent).toContain('Please enter your email address');
+    httpMock.expectNone('/api/newsletter/subscribe');
+  });
+
+  // AC3: Invalid Email Rejected
+  it('should show error for invalid email and make no request', () => {
+    setup();
+    component.form.get('email')!.setValue('not-an-email');
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.emailErrorMessage).toBe('Please enter a valid email address.');
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.error-message')?.textContent).toContain('Please enter a valid email address');
+    httpMock.expectNone('/api/newsletter/subscribe');
+  });
+
+  // AC4: Duplicate Email Handled
+  it('should show duplicate message on 409 and preserve input', () => {
+    setup();
+    component.form.get('email')!.setValue('dup@example.com');
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.flush({}, { status: 409, statusText: 'Conflict' });
+    fixture.detectChanges();
+
+    expect(component.serverError).toContain('already subscribed');
+    expect(component.form.get('email')!.value).toBe('dup@example.com');
+    expect(service.setSubscribed).not.toHaveBeenCalled();
+  });
+
+  // AC5: Network Error Handled
+  it('should show error on network failure and preserve input', () => {
+    setup();
+    component.form.get('email')!.setValue('err@example.com');
+    component.onSubmit();
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.flush({}, { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(component.serverError).toContain('Something went wrong');
+    expect(component.form.get('email')!.value).toBe('err@example.com');
+  });
+
+  // AC6: Double-Submit Prevented
+  it('should disable button and prevent duplicate submissions while submitting', () => {
+    setup();
+    component.form.get('email')!.setValue('user@example.com');
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.formState).toBe('submitting');
+    const button = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain('Subscribing');
+
+    // Second submit should be no-op
+    component.onSubmit();
+    httpMock.expectOne('/api/newsletter/subscribe');
+  });
+
+  // AC7: Accessibility
+  it('should have proper aria attributes for accessibility', () => {
+    setup();
+    const el = fixture.nativeElement as HTMLElement;
+
+    // Visible label
+    const label = el.querySelector('label[for="email"]');
+    expect(label).toBeTruthy();
+    expect(label!.textContent).toContain('Email');
+
+    // Input exists
+    const input = el.querySelector('input#email') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    // Submit to trigger error
+    component.onSubmit();
+    fixture.detectChanges();
+
+    // aria-describedby links to error
+    expect(input.getAttribute('aria-describedby')).toBe('email-error');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    // Error has role="alert"
+    const errorDiv = el.querySelector('#email-error');
+    expect(errorDiv?.getAttribute('role')).toBe('alert');
+  });
+
+  it('should have aria-live on success message', () => {
+    setup();
+    component.form.get('email')!.setValue('user@example.com');
+    component.onSubmit();
+
+    httpMock.expectOne('/api/newsletter/subscribe').flush({});
+    fixture.detectChanges();
+
+    const successEl = fixture.nativeElement.querySelector('[aria-live="polite"]');
+    expect(successEl).toBeTruthy();
+    expect(successEl.textContent).toContain("You're subscribed!");
+  });
+
+  // AC8: Returning Subscriber Suppressed
+  it('should show already subscribed message when localStorage flag is set', () => {
+    setup(true);
+
+    expect(component.formState).toBe('already-subscribed');
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.already-subscribed-message')?.textContent).toContain("You're already subscribed");
+    expect(el.querySelector('form')).toBeNull();
+  });
+
+  // Honeypot
+  it('should silently simulate success when honeypot is filled', () => {
+    setup();
+    component.form.get('email')!.setValue('bot@example.com');
+    component.form.get('website')!.setValue('http://spam.com');
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.formState).toBe('success');
+    httpMock.expectNone('/api/newsletter/subscribe');
+    expect(service.setSubscribed).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/features/newsletter/newsletter.component.ts
+++ b/src/app/features/newsletter/newsletter.component.ts
@@ -1,0 +1,105 @@
+import { Component, OnInit, OnDestroy, inject, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { NewsletterService } from './newsletter.service';
+import { NewsletterResult } from './newsletter.model';
+import { Subscription } from 'rxjs';
+
+export type FormState = 'idle' | 'submitting' | 'success' | 'error' | 'already-subscribed';
+
+const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+export function strictEmailValidator(control: AbstractControl): ValidationErrors | null {
+  if (!control.value) return null;
+  return EMAIL_REGEX.test(control.value) ? null : { strictEmail: true };
+}
+
+@Component({
+  selector: 'app-newsletter',
+  standalone: true,
+  imports: [CommonModule, RouterModule, ReactiveFormsModule],
+  templateUrl: './newsletter.component.html',
+  styleUrls: ['./newsletter.component.css'],
+})
+export class NewsletterComponent implements OnInit, OnDestroy {
+  private readonly fb = inject(FormBuilder);
+  private readonly newsletterService = inject(NewsletterService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  formState: FormState = 'idle';
+  serverError = '';
+  form!: FormGroup;
+  private submitSubscription?: Subscription;
+
+  ngOnInit(): void {
+    if (this.newsletterService.isSubscribed()) {
+      this.formState = 'already-subscribed';
+      return;
+    }
+
+    this.form = this.fb.group({
+      email: ['', {
+        validators: [Validators.required, Validators.email, Validators.maxLength(254), strictEmailValidator],
+        updateOn: 'change',
+      }],
+      website: [''],
+    });
+  }
+
+  get emailControl() {
+    return this.form.get('email')!;
+  }
+
+  get emailErrorMessage(): string {
+    if (this.emailControl.hasError('required')) {
+      return 'Please enter your email address.';
+    }
+    if (this.emailControl.hasError('email') || this.emailControl.hasError('strictEmail')) {
+      return 'Please enter a valid email address.';
+    }
+    if (this.emailControl.hasError('maxlength')) {
+      return 'Please enter a valid email address.';
+    }
+    return '';
+  }
+
+  get showEmailError(): boolean {
+    return this.emailControl.invalid && (this.emailControl.dirty || this.emailControl.touched);
+  }
+
+  onSubmit(): void {
+    if (this.formState === 'submitting') return;
+
+    this.serverError = '';
+    this.emailControl.markAsTouched();
+
+    if (this.form.invalid) return;
+
+    // Honeypot check
+    if (this.form.get('website')!.value) {
+      this.formState = 'success';
+      return;
+    }
+
+    this.formState = 'submitting';
+
+    this.submitSubscription = this.newsletterService.subscribe(this.emailControl.value.trim()).subscribe((result: NewsletterResult) => {
+      if (result.status === 'success') {
+        this.formState = 'success';
+        this.newsletterService.setSubscribed();
+      } else if (result.status === 'duplicate') {
+        this.formState = 'error';
+        this.serverError = result.message;
+      } else {
+        this.formState = 'error';
+        this.serverError = result.message;
+      }
+      this.cdr.detectChanges();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.submitSubscription?.unsubscribe();
+  }
+}

--- a/src/app/features/newsletter/newsletter.model.ts
+++ b/src/app/features/newsletter/newsletter.model.ts
@@ -1,0 +1,4 @@
+export interface NewsletterResult {
+  status: 'success' | 'duplicate' | 'error';
+  message: string;
+}

--- a/src/app/features/newsletter/newsletter.service.spec.ts
+++ b/src/app/features/newsletter/newsletter.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { NewsletterService } from './newsletter.service';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('NewsletterService', () => {
+  let service: NewsletterService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(NewsletterService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should map 200 response to success', () => {
+    service.subscribe('test@example.com').subscribe((result) => {
+      expect(result.status).toBe('success');
+      expect(result.message).toContain('subscribed');
+    });
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email: 'test@example.com' });
+    req.flush({});
+  });
+
+  it('should map 409 response to duplicate', () => {
+    service.subscribe('dup@example.com').subscribe((result) => {
+      expect(result.status).toBe('duplicate');
+      expect(result.message).toContain('already subscribed');
+    });
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.flush({}, { status: 409, statusText: 'Conflict' });
+  });
+
+  it('should map 500 response to error', () => {
+    service.subscribe('err@example.com').subscribe((result) => {
+      expect(result.status).toBe('error');
+      expect(result.message).toContain('Something went wrong');
+    });
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.flush({}, { status: 500, statusText: 'Server Error' });
+  });
+
+  it('should map network error to error', () => {
+    service.subscribe('net@example.com').subscribe((result) => {
+      expect(result.status).toBe('error');
+      expect(result.message).toContain('Something went wrong');
+    });
+
+    const req = httpMock.expectOne('/api/newsletter/subscribe');
+    req.error(new ProgressEvent('error'));
+  });
+
+  it('should read and write localStorage for subscription flag', () => {
+    const store: Record<string, string> = {};
+    vi.spyOn(service, 'getStorageItem').mockImplementation((key) => store[key] ?? null);
+    vi.spyOn(service, 'setStorageItem').mockImplementation((key, val) => { store[key] = val; });
+
+    expect(service.isSubscribed()).toBe(false);
+    service.setSubscribed();
+    expect(service.isSubscribed()).toBe(true);
+  });
+});

--- a/src/app/features/newsletter/newsletter.service.ts
+++ b/src/app/features/newsletter/newsletter.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, catchError, map } from 'rxjs';
+import { NewsletterResult } from './newsletter.model';
+
+@Injectable({ providedIn: 'root' })
+export class NewsletterService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = '/api/newsletter/subscribe';
+  private readonly storageKey = 'newsletter_subscribed';
+
+  subscribe(email: string): Observable<NewsletterResult> {
+    return this.http.post<{ message?: string }>(this.apiUrl, { email }).pipe(
+      map(() => ({
+        status: 'success' as const,
+        message: "You're subscribed! Check your inbox for a welcome email.",
+      })),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 409) {
+          return of({
+            status: 'duplicate' as const,
+            message: 'This email is already subscribed.',
+          });
+        }
+        return of({
+          status: 'error' as const,
+          message: 'Something went wrong. Please try again.',
+        });
+      })
+    );
+  }
+
+  isSubscribed(): boolean {
+    return !!this.getStorageItem(this.storageKey);
+  }
+
+  setSubscribed(): void {
+    this.setStorageItem(this.storageKey, 'true');
+  }
+
+  getStorageItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  setStorageItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // localStorage unavailable
+    }
+  }
+}


### PR DESCRIPTION
## Story
**SAM1-276**: **Hypothesis**

## Acceptance Criteria
- Given the form is displayed, when the user enters a valid email and clicks Subscribe, then the form is replaced by a success confirmation message and newsletter_subscribed is set in localStorage.
- Given the email field is empty, when the user clicks Subscribe, then submission is prevented and 'Please enter your email address' appears below the input.
- Given the user enters an invalid email (including via paste or autofill), when they click Subscribe, then 'Please enter a valid email address' appears below the input and no network request is made.
- Given the server returns HTTP 409 for a duplicate email, when the user submits, then 'This email is already subscribed' is shown inline and the user's input is preserved.
- Given the server is unreachable or returns 5xx, when the user submits, then 'Something went wrong. Please try again.' is shown and the user's input is preserved.
- Given the user clicks Subscribe while a request is in flight, then the button remains disabled with a 'Subscribing…' label and no duplicate request is sent.
- Given any form state (idle, error, success), when navigated via keyboard or screen reader, then all elements are reachable via Tab, errors are announced via aria-describedby, success is announced via aria-live, and no axe-core critical violations exist.
- Given newsletter_subscribed exists in localStorage, when the user visits the newsletter page, then the subscription form is not displayed and a 'You're already subscribed' message is shown instead.

## Implementation Details
### Architecture
# Technical Architecture Review

## Observation

The user story and acceptance criteria are both empty. There is no feature description, no requirements, and no acceptance criteria to analyze. I cannot produce a meaningful architecture review without knowing what is being built.

---

## What I Need to Proceed

Before I can provide data model changes, API contracts, component boundaries, or risk analysis, I need the following:

- **The user story itself** — a clear description of the feature or behavior being requested (e.g., "As a user, I want to log in with email and password so that I can a

### Developer Notes
**Angular Architecture**
- Build as a standalone component at `src/app/features/newsletter/`. No NgModule — use `standalone: true` with direct imports of `ReactiveFormsModule`.
- Register route `{ path: 'newsletter', component: NewsletterComponent }` in `app.routes.ts`. Add a default redirect if this is the first feature.
- Add `provideHttpClient()` to `app.config.ts` providers — this is a prerequisite flagged by the architect.

**Component Design**
- Use a `formState` signal or property with values `'idle' | 'submitting' | 'success' | 'error'` to drive template rendering.
- Use Reactive Forms

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/e2e/newsletter.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/package.json`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/playwright.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/features/newsletter/newsletter.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Build a newsletter subscription form that allows users to enter their email and submit it. -->
<!-- bmad:team_id=SAM1 -->