### PR TITLE
feat(SAM1): Add a health check endpoint that returns JSON with status an [SAM1-328]

### DIFF
--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Health Check Page', () => {
+  test('renders valid JSON with status UP, uptime as number, and ISO 8601 timestamp', async ({ page }) => {
+    await page.goto('/health');
+
+    const pre = page.getByRole('status').locator('pre');
+    await expect(pre).toBeVisible();
+
+    const text = await pre.textContent();
+    expect(text).toBeTruthy();
+
+    const json = JSON.parse(text!);
+    expect(json.status).toBe('UP');
+    expect(typeof json.uptime).toBe('number');
+    expect(Number.isInteger(json.uptime)).toBe(true);
+    expect(json.uptime).toBeGreaterThanOrEqual(0);
+    // Validate ISO 8601 timestamp
+    expect(typeof json.timestamp).toBe('string');
+    const parsed = new Date(json.timestamp);
+    expect(parsed.toISOString()).toBe(json.timestamp);
+  });
+
+  test('uptime is a non-negative integer representing seconds since bootstrap', async ({ page }) => {
+    await page.goto('/health');
+
+    const pre = page.getByRole('status').locator('pre');
+    await expect(pre).toBeVisible();
+
+    const json = JSON.parse((await pre.textContent())!);
+    // Uptime should be a non-negative integer (0 is valid right after bootstrap)
+    expect(Number.isInteger(json.uptime)).toBe(true);
+    expect(json.uptime).toBeGreaterThanOrEqual(0);
+    // App just bootstrapped, uptime should be small (within ±2s tolerance)
+    expect(json.uptime).toBeLessThan(30);
+  });
+
+  test('loads without auth redirects - URL stays at /health', async ({ page }) => {
+    await page.goto('/health');
+
+    await expect(page.getByRole('status').locator('pre')).toBeVisible();
+    expect(page.url()).toContain('/health');
+  });
+
+  test('sets browser tab title to Health Check', async ({ page }) => {
+    await page.goto('/health');
+
+    await expect(page.getByRole('status').locator('pre')).toBeVisible();
+    await expect(page).toHaveTitle('Health Check');
+  });
+
+  test('renders no layout chrome - only the pre element with JSON', async ({ page }) => {
+    await page.goto('/health');
+
+    const pre = page.getByRole('status').locator('pre');
+    await expect(pre).toBeVisible();
+
+    // No nav, header, footer, sidebar elements should be visible
+    await expect(page.locator('nav')).toHaveCount(0);
+    await expect(page.locator('footer')).toHaveCount(0);
+    // The role="status" host element should contain only the pre tag
+    const statusEl = page.getByRole('status');
+    const childCount = await statusEl.locator('> *').count();
+    expect(childCount).toBe(1);
+  });
+
+  test('page renders within reasonable time', async ({ page }) => {
+    const start = Date.now();
+    await page.goto('/health');
+    await expect(page.getByRole('status').locator('pre')).toBeVisible();
+    const elapsed = Date.now() - start;
+    // Should render well under 5s (generous for CI; story says <100ms from route activation)
+    expect(elapsed).toBeLessThan(5000);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:4200',
+  },
+  webServer: {
+    command: 'npx ng serve --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,15 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+// TODO: This /health route is a client-side health page, NOT an HTTP API endpoint.
+// Automated infrastructure consumers (Kubernetes liveness probes, AWS ALB health checks,
+// Datadog) cannot consume it without executing JavaScript.
+// Follow-up ticket needed: server-side /api/health endpoint for Kubernetes probes and load balancers.
+export const routes: Routes = [
+  {
+    path: 'health',
+    loadComponent: () =>
+      import('./health/health-check.component').then(
+        (m) => m.HealthCheckComponent
+      ),
+  },
+];

--- a/src/app/health/health-check.component.spec.ts
+++ b/src/app/health/health-check.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { HealthCheckComponent } from './health-check.component';
+import { HealthService } from './health.service';
+import { AnalyticsService } from '../shared/analytics.service';
+import { HealthResponse } from './health.model';
+
+describe('HealthCheckComponent', () => {
+  let fixture: ComponentFixture<HealthCheckComponent>;
+  let component: HealthCheckComponent;
+  let mockHealthService: { getHealth: ReturnType<typeof vi.fn> };
+  let mockAnalytics: { track: ReturnType<typeof vi.fn> };
+
+  const mockResponse: HealthResponse = {
+    status: 'UP',
+    uptime: 42,
+    timestamp: '2025-01-15T12:00:00.000Z',
+  };
+
+  beforeEach(async () => {
+    mockHealthService = { getHealth: vi.fn().mockReturnValue(mockResponse) };
+    mockAnalytics = { track: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [HealthCheckComponent],
+      providers: [
+        { provide: HealthService, useValue: mockHealthService },
+        { provide: AnalyticsService, useValue: mockAnalytics },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HealthCheckComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render valid JSON in a <pre> element', () => {
+    const pre = fixture.nativeElement.querySelector('pre');
+    expect(pre).toBeTruthy();
+    const parsed = JSON.parse(pre.textContent!);
+    expect(parsed.status).toBe('UP');
+    expect(parsed.uptime).toBe(42);
+    expect(parsed.timestamp).toBe('2025-01-15T12:00:00.000Z');
+  });
+
+  it('should contain all HealthResponse fields in rendered JSON', () => {
+    const pre = fixture.nativeElement.querySelector('pre');
+    const parsed = JSON.parse(pre.textContent!);
+    expect(parsed).toHaveProperty('status');
+    expect(parsed).toHaveProperty('uptime');
+    expect(parsed).toHaveProperty('timestamp');
+  });
+
+  it('should set browser tab title to "Health Check"', () => {
+    const titleService = TestBed.inject(Title);
+    expect(titleService.getTitle()).toBe('Health Check');
+  });
+
+  it('should have role="status" on host element', () => {
+    const hostEl = fixture.nativeElement;
+    expect(hostEl.getAttribute('role')).toBe('status');
+  });
+
+  it('should fire health_check_requested analytics event', () => {
+    expect(mockAnalytics.track).toHaveBeenCalledWith('health_check_requested', {
+      timestamp: '2025-01-15T12:00:00.000Z',
+      uptime: 42,
+      status: 'UP',
+    });
+  });
+
+  it('should render formatted JSON with indentation', () => {
+    const expected = JSON.stringify(mockResponse, null, 2);
+    expect(component.payload).toBe(expected);
+  });
+});

--- a/src/app/health/health-check.component.ts
+++ b/src/app/health/health-check.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { HealthService } from './health.service';
+import { HealthResponse } from './health.model';
+import { AnalyticsService } from '../shared/analytics.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-health-check',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { role: 'status' },
+  styles: `:host { display: block; font-family: monospace; }`,
+  template: `<pre>{{ payload }}</pre>`,
+})
+export class HealthCheckComponent {
+  private readonly healthService = inject(HealthService);
+  private readonly titleService = inject(Title);
+  private readonly analytics = inject(AnalyticsService);
+
+  readonly payload: string;
+
+  constructor() {
+    this.titleService.setTitle('Health Check');
+    const health: HealthResponse = this.healthService.getHealth();
+    this.payload = JSON.stringify(health, null, 2);
+    this.analytics.track('health_check_requested', {
+      timestamp: health.timestamp,
+      uptime: health.uptime,
+      status: health.status,
+    });
+  }
+}

--- a/src/app/health/health-routes.spec.ts
+++ b/src/app/health/health-routes.spec.ts
@@ -1,0 +1,33 @@
+import { routes } from '../app.routes';
+
+describe('Health route configuration', () => {
+  const healthRoute = routes.find((r) => r.path === 'health');
+
+  it('should have a /health route defined', () => {
+    expect(healthRoute).toBeDefined();
+  });
+
+  it('should use loadComponent for lazy loading', () => {
+    expect(healthRoute!.loadComponent).toBeDefined();
+    expect(typeof healthRoute!.loadComponent).toBe('function');
+  });
+
+  it('should not have any route guards', () => {
+    expect(healthRoute!.canActivate).toBeUndefined();
+    expect(healthRoute!.canActivateChild).toBeUndefined();
+    expect(healthRoute!.canDeactivate).toBeUndefined();
+    expect(healthRoute!.canMatch).toBeUndefined();
+  });
+
+  it('should not have redirect logic', () => {
+    expect(healthRoute!.redirectTo).toBeUndefined();
+  });
+
+  it('should lazy-load HealthCheckComponent', async () => {
+    const component = await healthRoute!.loadComponent!() as any;
+    // loadComponent returns the component class (or a module with the component)
+    const resolved = component.HealthCheckComponent ?? component;
+    expect(resolved).toBeDefined();
+    expect(resolved.name).toContain('HealthCheckComponent');
+  });
+});

--- a/src/app/health/health.model.ts
+++ b/src/app/health/health.model.ts
@@ -1,0 +1,5 @@
+export interface HealthResponse {
+  status: 'UP' | 'DOWN';
+  uptime: number;
+  timestamp: string;
+}

--- a/src/app/health/health.service.spec.ts
+++ b/src/app/health/health.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { HealthService } from './health.service';
+import { HealthResponse } from './health.model';
+
+describe('HealthService', () => {
+  let service: HealthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HealthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return status UP', () => {
+    const health: HealthResponse = service.getHealth();
+    expect(health.status).toBe('UP');
+  });
+
+  it('should return uptime as a non-negative integer', () => {
+    const health = service.getHealth();
+    expect(typeof health.uptime).toBe('number');
+    expect(health.uptime).toBeGreaterThanOrEqual(0);
+    expect(health.uptime).toBe(Math.floor(health.uptime));
+  });
+
+  it('should return a valid ISO 8601 timestamp', () => {
+    const health = service.getHealth();
+    const parsed = new Date(health.timestamp);
+    expect(parsed.toISOString()).toBe(health.timestamp);
+  });
+
+  it('should return HealthResponse with all required fields', () => {
+    const health = service.getHealth();
+    expect(health).toHaveProperty('status');
+    expect(health).toHaveProperty('uptime');
+    expect(health).toHaveProperty('timestamp');
+  });
+
+  it('should use performance.now() for monotonic uptime', () => {
+    const perfSpy = vi.spyOn(performance, 'now');
+    service.getHealth();
+    expect(perfSpy).toHaveBeenCalled();
+    perfSpy.mockRestore();
+  });
+
+  it('should be a singleton (same instance from root injector)', () => {
+    const service2 = TestBed.inject(HealthService);
+    expect(service).toBe(service2);
+  });
+
+  it('should calculate uptime accurately within ±2s tolerance', () => {
+    // Mock performance.now to control the start mark and elapsed time
+    const mockStart = 1000;
+    const mockCurrent = 6000; // 5 seconds later
+    const perfSpy = vi.spyOn(performance, 'now').mockReturnValue(mockStart);
+
+    const freshService = new HealthService();
+
+    // Now simulate 5 seconds passing
+    perfSpy.mockReturnValue(mockCurrent);
+
+    const health = freshService.getHealth();
+    expect(health.uptime).toBe(5);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/src/app/health/health.service.ts
+++ b/src/app/health/health.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HealthResponse } from './health.model';
+
+/**
+ * Singleton health service that tracks application uptime using a monotonic clock.
+ *
+ * Uses `performance.now()` instead of `Date.now()` to ensure uptime calculation
+ * is immune to NTP sync or system clock adjustments.
+ *
+ * NOTE: If SSR is adopted later, this service will be per-request scoped with
+ * near-zero uptime. The server-side follow-up endpoint should use
+ * `process.uptime()` instead. See TODO in app.routes.ts.
+ */
+@Injectable({ providedIn: 'root' })
+export class HealthService {
+  private readonly startMark = performance.now();
+
+  getHealth(): HealthResponse {
+    return {
+      status: 'UP',
+      uptime: Math.floor((performance.now() - this.startMark) / 1000),
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/src/app/shared/analytics.service.spec.ts
+++ b/src/app/shared/analytics.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AnalyticsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should be a singleton (providedIn root)', () => {
+    const service2 = TestBed.inject(AnalyticsService);
+    expect(service).toBe(service2);
+  });
+
+  it('should log to console.debug when track is called', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    service.track('test_event', { key: 'value' });
+    expect(debugSpy).toHaveBeenCalledWith('[Analytics] test_event', { key: 'value' });
+    debugSpy.mockRestore();
+  });
+
+  it('should accept any event name and meta object', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    expect(() => service.track('', {})).not.toThrow();
+    expect(() => service.track('health_check_requested', { timestamp: 'x', uptime: 0, status: 'UP' })).not.toThrow();
+    debugSpy.mockRestore();
+  });
+});

--- a/src/app/shared/analytics.service.ts
+++ b/src/app/shared/analytics.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Stub analytics service that logs events to console.debug.
+ *
+ * TODO: Before connecting to a real analytics pipeline, evaluate sampling
+ * or a separate low-priority event stream. High-frequency polling of the
+ * /health route could generate excessive event volume.
+ */
+@Injectable({ providedIn: 'root' })
+export class AnalyticsService {
+  track(eventName: string, meta: Record<string, unknown>): void {
+    console.debug(`[Analytics] ${eventName}`, meta);
+  }
+}


### PR DESCRIPTION
## Story
**SAM1-328**: **Hypothesis**

## Acceptance Criteria
- **Given** the app is running **When** a user navigates to `/health` **Then** the page renders a `<pre>` element containing valid JSON with `status: "UP"`, `uptime` as a number (seconds), and `timestamp` as a valid ISO 8601 string
- **Given** the app bootstrapped N seconds ago **When** `/health` is accessed **Then** the `uptime` value equals N within ±2s tolerance, calculated using `performance.now()` (monotonic clock)
- **Given** the app routes config **When** `/health` is navigated to **Then** the `HealthCheckComponent` loads via lazy `loadComponent` dynamic import without any auth guard redirects or interceptor interference
- **Given** the app has a shell layout with nav/footer **When** `/health` is rendered **Then** no layout chrome is visible — only the `<pre>` JSON output with `role="status"` on the host element and browser tab title set to "Health Check"
- **Given** Angular standalone architecture **When** `HealthCheckComponent` and `HealthService` are inspected **Then** both use standalone patterns (`providedIn: 'root'`, `standalone: true`), no `NgModule` exists, and the component uses `ChangeDetectionStrategy.OnPush`
- **Given** the new spec files **When** the Vitest suite runs **Then** all tests pass covering: uptime calculation accuracy, `HealthResponse` JSON schema compliance, singleton service behavior, and rendered `<pre>` content validity
- **Given** the health route is activated **When** the component initializes **Then** a `health_check_requested` event is fired via the stubbed `AnalyticsService` with `timestamp`, `uptime`, and `status` properties
- **Given** the route file and project docs **When** reviewed **Then** a TODO comment documents that this is a client-side health page (not an HTTP API) and that a follow-up ticket is required for a server-side health endpoint for infrastructure probes

## Implementation Details
### Architecture


# Technical Architecture Review: Health Check Endpoint

## Data Model Changes

No persistent data model or database changes are required. The only runtime state is a single `number` representing the bootstrap timestamp, held in memory by `HealthService`.

Define a TypeScript interface for the health response payload:

```typescript
// src/app/health/health.model.ts
export interface HealthResponse {
  status: 'UP' | 'DOWN';
  uptime: number; // elapsed seconds since bootstrap
}
```

This interface serves as the contract for both the service return type and the rendered output. Keep it in its 

### Developer Notes
**File structure — all new code under `src/app/health/`:**
- `health.model.ts` — `HealthResponse` interface: `{ status: 'UP' | 'DOWN'; uptime: number; timestamp: string; }`
- `health.service.ts` — `providedIn: 'root'` singleton capturing `performance.now()` at instantiation; `getHealth()` returns typed `HealthResponse` with `Math.floor((performance.now() - startMark) / 1000)` for uptime and `new Date().toISOString()` for timestamp
- `health-check.component.ts` — standalone, `OnPush`, renders `JSON.stringify(payload, null, 2)` in `<pre>` tag; sets `host: { role: 'status' }`; uses Angular `Title

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/e2e/health.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/playwright.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health-check.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health-check.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health-routes.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health.model.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/health/health.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/analytics.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/analytics.service.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
No code review issues found.

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Add a health check endpoint that returns JSON with status and uptime -->
<!-- bmad:team_id=SAM1 -->