### PR TITLE
feat(SAM1): Create a more advanced full-stack SaaS-style application wit [SAM1-374]

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+async function fillAndBlur(page: import('@playwright/test').Page, label: string, value: string, exact = false) {
+  const input = page.getByLabel(label, { exact });
+  await input.fill(value);
+  await input.blur();
+}
+
+test.describe('Login Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  test('displays login heading and form fields', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1, name: 'Log in' })).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Log in' })).toBeVisible();
+  });
+
+  test('submit button is disabled when form is empty', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Log in' })).toBeDisabled();
+  });
+
+  test('shows email required error when field is touched and left empty', async ({ page }) => {
+    const emailInput = page.getByLabel('Email');
+    await emailInput.focus();
+    await emailInput.blur();
+    await expect(page.getByRole('alert').filter({ hasText: 'required' })).toBeVisible();
+  });
+
+  test('shows invalid email error for bad format', async ({ page }) => {
+    await fillAndBlur(page, 'Email', 'notanemail');
+    await expect(page.getByRole('alert').filter({ hasText: 'valid email' })).toBeVisible();
+  });
+
+  test('shows password min length error', async ({ page }) => {
+    await fillAndBlur(page, 'Password', 'short', true);
+    await expect(page.getByRole('alert').filter({ hasText: '8 characters' })).toBeVisible();
+  });
+
+  test('submit button enables with valid input', async ({ page }) => {
+    await fillAndBlur(page, 'Email', 'test@example.com');
+    await fillAndBlur(page, 'Password', 'password1', true);
+    await expect(page.getByRole('button', { name: 'Log in' })).toBeEnabled();
+  });
+
+  test('toggle password visibility', async ({ page }) => {
+    const pwInput = page.getByLabel('Password', { exact: true });
+    await pwInput.fill('password1');
+    await expect(pwInput).toHaveAttribute('type', 'password');
+
+    const toggleBtn = page.getByRole('button', { name: 'Show password' });
+    await toggleBtn.click();
+    await expect(pwInput).toHaveAttribute('type', 'text');
+    await expect(page.getByRole('button', { name: 'Hide password' })).toBeVisible();
+  });
+
+  test('shows API error on failed login', async ({ page }) => {
+    await page.route('**/api/auth/login', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'INVALID_CREDENTIALS', message: 'Invalid' }),
+      })
+    );
+
+    await fillAndBlur(page, 'Email', 'test@example.com');
+    await fillAndBlur(page, 'Password', 'password1', true);
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page.getByRole('alert').filter({ hasText: 'Invalid email or password' })).toBeVisible();
+  });
+
+  test('navigates to dashboard on successful login', async ({ page }) => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const h = btoa(JSON.stringify({ alg: 'HS256' }));
+    const b = btoa(JSON.stringify({ sub: 'u1', exp }));
+    const token = `${h}.${b}.sig`;
+
+    await page.route('**/api/auth/login', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          token,
+          user: { id: 'u1', email: 'test@example.com', name: 'Test' },
+        }),
+      })
+    );
+
+    await fillAndBlur(page, 'Email', 'test@example.com');
+    await fillAndBlur(page, 'Password', 'password1', true);
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('has link to register page', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Register' })).toBeVisible();
+  });
+
+  test('uses main landmark for auth page', async ({ page }) => {
+    await expect(page.getByRole('main').filter({ hasText: 'Log in' })).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:e2e": "playwright test"
   },
   "private": true,
   "packageManager": "npm@11.6.2",
@@ -24,6 +25,7 @@
     "@angular/build": "^21.2.0",
     "@angular/cli": "^21.2.0",
     "@angular/compiler-cli": "^21.2.0",
+    "@playwright/test": "^1.59.0",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4200',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: 'npx ng serve --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { authInterceptor } from './auth/interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient(withInterceptors([authInterceptor]))
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,12 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './auth/guards/auth.guard';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'login', loadComponent: () => import('./auth/login/login.component').then(m => m.LoginComponent) },
+  { path: 'register', loadComponent: () => import('./auth/register/register.component').then(m => m.RegisterComponent) },
+  { path: 'dashboard', loadComponent: () => import('./dashboard/dashboard.component').then(m => m.DashboardComponent), canActivate: [authGuard] },
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+  // Wildcard intentionally redirects to 'dashboard'. The authGuard on /dashboard will cascade
+  // unauthenticated users to /login?returnUrl=/dashboard, preventing unguarded access to any typo URL.
+  { path: '**', redirectTo: 'dashboard' }
+];

--- a/src/app/auth/guards/auth.guard.spec.ts
+++ b/src/app/auth/guards/auth.guard.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { AuthService } from '../services/auth.service';
+import { authGuard } from './auth.guard';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+
+describe('authGuard', () => {
+  let authService: AuthService;
+  let router: Router;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+      ]
+    });
+    authService = TestBed.inject(AuthService);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  function runGuard(url: string): boolean | UrlTree {
+    const route = {} as ActivatedRouteSnapshot;
+    const state = { url } as RouterStateSnapshot;
+    return TestBed.runInInjectionContext(() => authGuard(route, state)) as boolean | UrlTree;
+  }
+
+  it('returns true when authenticated', () => {
+    vi.spyOn(authService, 'isAuthenticated').mockReturnValue(true);
+    expect(runGuard('/dashboard')).toBe(true);
+  });
+
+  it('returns UrlTree to /login with returnUrl when not authenticated', () => {
+    vi.spyOn(authService, 'isAuthenticated').mockReturnValue(false);
+    const result = runGuard('/dashboard') as UrlTree;
+    expect(result.toString()).toBe('/login?returnUrl=%2Fdashboard');
+  });
+
+  it('preserves complex returnUrl paths', () => {
+    vi.spyOn(authService, 'isAuthenticated').mockReturnValue(false);
+    const result = runGuard('/projects/3/tasks') as UrlTree;
+    expect(result.toString()).toContain('returnUrl');
+    expect(result.toString()).toContain('projects');
+  });
+});

--- a/src/app/auth/guards/auth.guard.ts
+++ b/src/app/auth/guards/auth.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+import { trackEvent } from '../../shared/utils/analytics';
+
+export const authGuard: CanActivateFn = (_route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+
+  trackEvent('auth_guard_redirect', { targetRoute: state.url });
+  return router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
+};

--- a/src/app/auth/interceptors/auth.interceptor.spec.ts
+++ b/src/app/auth/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptors, HttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authService: AuthService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+      ]
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('attaches Authorization header to /api/ requests when token exists', () => {
+    localStorage.setItem('auth_token', 'my-token');
+    http.get('/api/data').subscribe();
+    const req = httpMock.expectOne('/api/data');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer my-token');
+    req.flush({});
+  });
+
+  it('does not attach header to non-/api/ requests', () => {
+    localStorage.setItem('auth_token', 'my-token');
+    http.get('/other/data').subscribe();
+    const req = httpMock.expectOne('/other/data');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+
+  it('does not attach header when no token', () => {
+    http.get('/api/data').subscribe();
+    const req = httpMock.expectOne('/api/data');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+
+  it('calls logout on 401 from /api/ endpoint', () => {
+    vi.spyOn(authService, 'logout');
+    http.get('/api/protected').subscribe({ error: () => {} });
+    const req = httpMock.expectOne('/api/protected');
+    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+    expect(authService.logout).toHaveBeenCalled();
+  });
+
+  it('does not call logout on 401 from non-/api/ endpoint', () => {
+    vi.spyOn(authService, 'logout');
+    http.get('/external/thing').subscribe({ error: () => {} });
+    const req = httpMock.expectOne('/external/thing');
+    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+    expect(authService.logout).not.toHaveBeenCalled();
+  });
+
+  it('does not call logout on non-401 errors from /api/', () => {
+    vi.spyOn(authService, 'logout');
+    http.get('/api/data').subscribe({ error: () => {} });
+    const req = httpMock.expectOne('/api/data');
+    req.flush('Error', { status: 500, statusText: 'Server Error' });
+    expect(authService.logout).not.toHaveBeenCalled();
+  });
+
+  it('re-throws the error after 401 logout', () => {
+    vi.spyOn(authService, 'logout');
+    let errorCaught = false;
+    http.get('/api/protected').subscribe({
+      error: () => { errorCaught = true; }
+    });
+    httpMock.expectOne('/api/protected').flush('', { status: 401, statusText: 'Unauthorized' });
+    expect(errorCaught).toBe(true);
+  });
+});

--- a/src/app/auth/interceptors/auth.interceptor.ts
+++ b/src/app/auth/interceptors/auth.interceptor.ts
@@ -1,0 +1,27 @@
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { trackEvent } from '../../shared/utils/analytics';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.getToken();
+
+  let request = req;
+  if (token && req.url.includes('/api/')) {
+    request = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` }
+    });
+  }
+
+  return next(request).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401 && req.url.includes('/api/') && !req.url.includes('/api/auth/login') && !req.url.includes('/api/auth/register')) {
+        trackEvent('auth_token_expired', { requestUrl: req.url });
+        auth.logout();
+      }
+      return throwError(() => error);
+    })
+  );
+};

--- a/src/app/auth/login/login.component.css
+++ b/src/app/auth/login/login.component.css
@@ -1,0 +1,150 @@
+.auth-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+h1 {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+}
+
+.form-field {
+  margin-bottom: 1rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+input[aria-invalid="true"] {
+  border-color: #d32f2f;
+}
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.eye-icon {
+  font-style: normal;
+}
+
+.field-error {
+  color: #d32f2f;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.error-icon {
+  font-size: 0.85rem;
+}
+
+.api-error {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border: 1px solid #d32f2f;
+  border-radius: 4px;
+  background: #fef2f2;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.625rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #1976d2;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid #fff;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.forgot-password-placeholder {
+  height: 0;
+}
+
+.auth-link {
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+
+.auth-link a {
+  color: #1976d2;
+  text-decoration: none;
+}
+
+.auth-link a:hover {
+  text-decoration: underline;
+}

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -1,0 +1,87 @@
+<main class="auth-page">
+  <div class="auth-card">
+    <h1>Log in</h1>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="form-field">
+        <label for="login-email">Email</label>
+        <input
+          id="login-email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          [attr.aria-invalid]="form.get('email')?.invalid && form.get('email')?.touched"
+          [attr.aria-describedby]="form.get('email')?.invalid && form.get('email')?.touched ? 'login-email-error' : null"
+        />
+        @if (form.get('email')?.invalid && form.get('email')?.touched) {
+          <div id="login-email-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            @if (form.get('email')?.hasError('required')) {
+              Email is required
+            } @else {
+              Please enter a valid email address
+            }
+          </div>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="login-password">Password</label>
+        <div class="password-wrapper">
+          <input
+            id="login-password"
+            [type]="showPassword ? 'text' : 'password'"
+            formControlName="password"
+            autocomplete="current-password"
+            [attr.aria-invalid]="form.get('password')?.invalid && form.get('password')?.touched"
+            [attr.aria-describedby]="form.get('password')?.invalid && form.get('password')?.touched ? 'login-password-error' : null"
+          />
+          <button
+            type="button"
+            class="toggle-password"
+            (click)="togglePasswordVisibility()"
+            [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'"
+          >
+            @if (showPassword) {
+              <span class="eye-icon" aria-hidden="true">&#128065;&#xFE0E;</span>
+            } @else {
+              <span class="eye-icon" aria-hidden="true">&#128065;&#xFE0E;</span>
+            }
+          </button>
+        </div>
+        @if (form.get('password')?.invalid && form.get('password')?.touched) {
+          <div id="login-password-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            @if (form.get('password')?.hasError('required')) {
+              Password is required
+            } @else {
+              Password must be at least 8 characters
+            }
+          </div>
+        }
+      </div>
+
+      @if (errorMessage) {
+        <div class="api-error" role="alert">
+          <span class="error-icon" aria-hidden="true">&#9888;</span>
+          {{ errorMessage }}
+        </div>
+      }
+
+      <button type="submit" class="submit-btn" [disabled]="form.invalid || loading">
+        @if (loading) {
+          <span class="spinner" aria-hidden="true"></span>
+          Logging in...
+        } @else {
+          Log in
+        }
+      </button>
+    </form>
+
+    <!-- Reserved space for future "Forgot password?" link -->
+    <div class="forgot-password-placeholder"></div>
+
+    <p class="auth-link">
+      Don't have an account? <a routerLink="/register" [queryParams]="{ returnUrl: returnUrl }">Register</a>
+    </p>
+  </div>
+</main>

--- a/src/app/auth/login/login.component.spec.ts
+++ b/src/app/auth/login/login.component.spec.ts
@@ -222,8 +222,13 @@ describe('LoginComponent', () => {
     });
 
     it('api error has role=alert', () => {
-      fixture.autoDetectChanges(true);
-      component.errorMessage = 'Some error';
+      // Trigger a real API error to set errorMessage via the component's own logic
+      component.form.get('email')!.setValue('test@example.com');
+      component.form.get('password')!.setValue('password1');
+      fixture.detectChanges();
+      component.onSubmit();
+      fixture.detectChanges();
+      httpMock.expectOne('/api/auth/login').flush('', { status: 500, statusText: 'Error' });
       fixture.detectChanges();
       const apiErr = fixture.nativeElement.querySelector('.api-error');
       expect(apiErr?.getAttribute('role')).toBe('alert');

--- a/src/app/auth/login/login.component.spec.ts
+++ b/src/app/auth/login/login.component.spec.ts
@@ -1,0 +1,232 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter, Router } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthResponse } from '../models/auth.models';
+
+function makeJwt(exp: number): string {
+  const h = btoa(JSON.stringify({ alg: 'HS256' }));
+  const b = btoa(JSON.stringify({ sub: 'u1', exp }));
+  return `${h}.${b}.sig`;
+}
+
+const mockResponse: AuthResponse = {
+  token: makeJwt(Date.now() / 1000 + 3600),
+  user: { id: 'u1', email: 'test@example.com', name: 'Test' }
+};
+
+describe('LoginComponent', () => {
+  let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent;
+  let httpMock: HttpTestingController;
+  let router: Router;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([
+          { path: 'login', component: LoginComponent },
+          { path: 'dashboard', component: LoginComponent },
+        ]),
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('has email and password fields with correct validators', () => {
+    expect(component.form.get('email')).toBeTruthy();
+    expect(component.form.get('password')).toBeTruthy();
+  });
+
+  describe('form validation', () => {
+    it('is invalid when empty', () => {
+      expect(component.form.invalid).toBe(true);
+    });
+
+    it('shows email required error after touch', () => {
+      const emailCtrl = component.form.get('email')!;
+      emailCtrl.markAsTouched();
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('#login-email-error')?.textContent).toContain('required');
+    });
+
+    it('shows invalid email error', () => {
+      const emailCtrl = component.form.get('email')!;
+      emailCtrl.setValue('notanemail');
+      emailCtrl.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#login-email-error')?.textContent).toContain('valid email');
+    });
+
+    it('shows password min length error', () => {
+      const pwCtrl = component.form.get('password')!;
+      pwCtrl.setValue('short');
+      pwCtrl.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#login-password-error')?.textContent).toContain('8 characters');
+    });
+
+    it('sets aria-invalid on invalid touched email', () => {
+      component.form.get('email')!.markAsTouched();
+      fixture.detectChanges();
+      const input = fixture.nativeElement.querySelector('#login-email');
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('sets aria-describedby on invalid touched email', () => {
+      component.form.get('email')!.markAsTouched();
+      fixture.detectChanges();
+      const input = fixture.nativeElement.querySelector('#login-email');
+      expect(input.getAttribute('aria-describedby')).toBe('login-email-error');
+    });
+  });
+
+  describe('submit button', () => {
+    it('is disabled when form is invalid', () => {
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is enabled when form is valid', () => {
+      component.form.get('email')!.setValue('test@example.com');
+      component.form.get('password')!.setValue('password1');
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+  });
+
+  describe('onSubmit', () => {
+    beforeEach(() => {
+      component.form.get('email')!.setValue('test@example.com');
+      component.form.get('password')!.setValue('password1');
+      fixture.detectChanges();
+    });
+
+    it('does not submit if form is invalid', () => {
+      component.form.get('email')!.setValue('');
+      component.onSubmit();
+      httpMock.expectNone('/api/auth/login');
+    });
+
+    it('sets loading state and disables form on submit', () => {
+      component.onSubmit();
+      expect(component.loading).toBe(true);
+      expect(component.form.disabled).toBe(true);
+      httpMock.expectOne('/api/auth/login').flush(mockResponse);
+    });
+
+    it('navigates to /dashboard on success', () => {
+      vi.spyOn(router, 'navigateByUrl');
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/login').flush(mockResponse);
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/dashboard', { replaceUrl: true });
+    });
+
+    it('shows error on 401 without clearing form', () => {
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/login').flush(
+        { error: 'INVALID_CREDENTIALS', message: 'Invalid' },
+        { status: 401, statusText: 'Unauthorized' }
+      );
+      expect(component.errorMessage).toBe('Invalid email or password');
+      expect(component.form.get('email')!.value).toBe('test@example.com');
+      expect(component.loading).toBe(false);
+      expect(component.form.enabled).toBe(true);
+    });
+
+    it('shows network error message on status 0', () => {
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/login').error(new ProgressEvent('error'), { status: 0 });
+      expect(component.errorMessage).toContain('Unable to connect');
+    });
+
+    it('shows rate limit message on 429', () => {
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/login').flush('', { status: 429, statusText: 'Too Many' });
+      expect(component.errorMessage).toContain('Too many attempts');
+    });
+
+    it('shows generic error on 500', () => {
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/login').flush('', { status: 500, statusText: 'Error' });
+      expect(component.errorMessage).toContain('Something went wrong');
+    });
+
+    it('prevents double submit while loading', () => {
+      component.onSubmit();
+      component.onSubmit();
+      const reqs = httpMock.match('/api/auth/login');
+      expect(reqs.length).toBe(1);
+      reqs[0].flush(mockResponse);
+    });
+  });
+
+  describe('password visibility toggle', () => {
+    it('toggles showPassword', () => {
+      expect(component.showPassword).toBe(false);
+      component.togglePasswordVisibility();
+      expect(component.showPassword).toBe(true);
+    });
+
+    it('toggle button has correct aria-label', () => {
+      const btn = fixture.nativeElement.querySelector('.toggle-password') as HTMLButtonElement;
+      expect(btn.getAttribute('aria-label')).toBe('Show password');
+      btn.click();
+      fixture.detectChanges();
+      expect(btn.getAttribute('aria-label')).toBe('Hide password');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has visible labels for all inputs', () => {
+      const labels = fixture.nativeElement.querySelectorAll('label');
+      expect(labels.length).toBeGreaterThanOrEqual(2);
+      expect(fixture.nativeElement.querySelector('label[for="login-email"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('label[for="login-password"]')).toBeTruthy();
+    });
+
+    it('has h1 heading', () => {
+      expect(fixture.nativeElement.querySelector('h1')?.textContent).toContain('Log in');
+    });
+
+    it('uses main landmark', () => {
+      expect(fixture.nativeElement.querySelector('main')).toBeTruthy();
+    });
+
+    it('error messages have role=alert', () => {
+      component.form.get('email')!.markAsTouched();
+      fixture.detectChanges();
+      const errEl = fixture.nativeElement.querySelector('#login-email-error');
+      expect(errEl?.getAttribute('role')).toBe('alert');
+    });
+
+    it('api error has role=alert', () => {
+      fixture.autoDetectChanges(true);
+      component.errorMessage = 'Some error';
+      fixture.detectChanges();
+      const apiErr = fixture.nativeElement.querySelector('.api-error');
+      expect(apiErr?.getAttribute('role')).toBe('alert');
+    });
+  });
+});

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router, RouterLink, ActivatedRoute } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subscription } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { trackEvent } from '../../shared/utils/analytics';
+
+function sanitizeReturnUrl(url: string): string {
+  if (url && url.startsWith('/') && !url.startsWith('//')) {
+    return url;
+  }
+  return '/dashboard';
+}
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.css'
+})
+export class LoginComponent implements OnDestroy {
+  form: FormGroup;
+  loading = false;
+  errorMessage = '';
+  showPassword = false;
+
+  protected readonly returnUrl: string;
+
+  private subscription?: Subscription;
+  private timeoutId?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly auth: AuthService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute
+  ) {
+    this.returnUrl = sanitizeReturnUrl(this.route.snapshot.queryParams['returnUrl'] || '/dashboard');
+    this.form = this.fb.group({
+      email: ['', { validators: [Validators.required, Validators.email], updateOn: 'blur' }],
+      password: ['', { validators: [Validators.required, Validators.minLength(8)], updateOn: 'blur' }]
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
+  }
+
+  togglePasswordVisibility(): void {
+    this.showPassword = !this.showPassword;
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.loading) {
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+    this.form.disable();
+
+    const { email, password } = this.form.getRawValue();
+
+    this.timeoutId = setTimeout(() => {
+      this.loading = false;
+      this.form.enable();
+      this.errorMessage = 'Request timed out. Please try again.';
+    }, 10000);
+
+    this.subscription = this.auth.login(email, password).subscribe({
+      next: () => {
+        clearTimeout(this.timeoutId);
+        this.router.navigateByUrl(this.returnUrl, { replaceUrl: true });
+      },
+      error: (err: HttpErrorResponse) => {
+        clearTimeout(this.timeoutId);
+        this.loading = false;
+        this.form.enable();
+        this.errorMessage = this.mapError(err);
+        trackEvent('auth_login_failure', { reason: this.errorMessage });
+      }
+    });
+  }
+
+  private mapError(err: HttpErrorResponse): string {
+    if (err.status === 0) {
+      return 'Unable to connect. Please check your connection and try again.';
+    }
+    if (err.status === 401) {
+      return 'Invalid email or password';
+    }
+    if (err.status === 429) {
+      return 'Too many attempts. Please wait and try again.';
+    }
+    return 'Something went wrong. Please try again.';
+  }
+}

--- a/src/app/auth/models/auth.models.ts
+++ b/src/app/auth/models/auth.models.ts
@@ -1,0 +1,27 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: AuthUser;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+}
+
+export interface AuthErrorResponse {
+  error: string;
+  message: string;
+  details?: Array<{ field: string; message: string }>;
+}

--- a/src/app/auth/register/register.component.css
+++ b/src/app/auth/register/register.component.css
@@ -1,0 +1,146 @@
+.auth-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+h1 {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+}
+
+.form-field {
+  margin-bottom: 1rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+input[aria-invalid="true"] {
+  border-color: #d32f2f;
+}
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.eye-icon {
+  font-style: normal;
+}
+
+.field-error {
+  color: #d32f2f;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.error-icon {
+  font-size: 0.85rem;
+}
+
+.api-error {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border: 1px solid #d32f2f;
+  border-radius: 4px;
+  background: #fef2f2;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.625rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #1976d2;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid #fff;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.auth-link {
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+
+.auth-link a {
+  color: #1976d2;
+  text-decoration: none;
+}
+
+.auth-link a:hover {
+  text-decoration: underline;
+}

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -1,0 +1,131 @@
+<main class="auth-page">
+  <div class="auth-card">
+    <h1>Create your account</h1>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="form-field">
+        <label for="register-name">Name</label>
+        <input
+          id="register-name"
+          type="text"
+          formControlName="name"
+          autocomplete="name"
+          [attr.aria-invalid]="form.get('name')?.invalid && form.get('name')?.touched"
+          [attr.aria-describedby]="form.get('name')?.invalid && form.get('name')?.touched ? 'register-name-error' : null"
+        />
+        @if (form.get('name')?.invalid && form.get('name')?.touched) {
+          <div id="register-name-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            Name is required
+          </div>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="register-email">Email</label>
+        <input
+          id="register-email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          [attr.aria-invalid]="form.get('email')?.invalid && form.get('email')?.touched"
+          [attr.aria-describedby]="form.get('email')?.invalid && form.get('email')?.touched ? 'register-email-error' : null"
+        />
+        @if (form.get('email')?.invalid && form.get('email')?.touched) {
+          <div id="register-email-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            @if (form.get('email')?.hasError('required')) {
+              Email is required
+            } @else {
+              Please enter a valid email address
+            }
+          </div>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="register-password">Password</label>
+        <div class="password-wrapper">
+          <input
+            id="register-password"
+            [type]="showPassword ? 'text' : 'password'"
+            formControlName="password"
+            autocomplete="new-password"
+            [attr.aria-invalid]="form.get('password')?.invalid && form.get('password')?.touched"
+            [attr.aria-describedby]="form.get('password')?.invalid && form.get('password')?.touched ? 'register-password-error' : null"
+          />
+          <button
+            type="button"
+            class="toggle-password"
+            (click)="togglePasswordVisibility()"
+            [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'"
+          >
+            <span class="eye-icon" aria-hidden="true">&#128065;&#xFE0E;</span>
+          </button>
+        </div>
+        @if (form.get('password')?.invalid && form.get('password')?.touched) {
+          <div id="register-password-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            @if (form.get('password')?.hasError('required')) {
+              Password is required
+            } @else {
+              Password must be at least 8 characters
+            }
+          </div>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="register-confirm-password">Confirm Password</label>
+        <div class="password-wrapper">
+          <input
+            id="register-confirm-password"
+            [type]="showConfirmPassword ? 'text' : 'password'"
+            formControlName="confirmPassword"
+            autocomplete="new-password"
+            [attr.aria-invalid]="(form.get('confirmPassword')?.invalid && form.get('confirmPassword')?.touched) || (form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched)"
+            [attr.aria-describedby]="((form.get('confirmPassword')?.invalid || form.hasError('passwordMismatch')) && form.get('confirmPassword')?.touched) ? 'register-confirm-password-error' : null"
+          />
+          <button
+            type="button"
+            class="toggle-password"
+            (click)="toggleConfirmPasswordVisibility()"
+            [attr.aria-label]="showConfirmPassword ? 'Hide password' : 'Show password'"
+          >
+            <span class="eye-icon" aria-hidden="true">&#128065;&#xFE0E;</span>
+          </button>
+        </div>
+        @if (form.get('confirmPassword')?.hasError('required') && form.get('confirmPassword')?.touched) {
+          <div id="register-confirm-password-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            Please confirm your password
+          </div>
+        } @else if (form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched) {
+          <div id="register-confirm-password-error" class="field-error" role="alert">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            Passwords do not match
+          </div>
+        }
+      </div>
+
+      @if (errorMessage) {
+        <div class="api-error" role="alert">
+          <span class="error-icon" aria-hidden="true">&#9888;</span>
+          {{ errorMessage }}
+        </div>
+      }
+
+      <button type="submit" class="submit-btn" [disabled]="form.invalid || loading">
+        @if (loading) {
+          <span class="spinner" aria-hidden="true"></span>
+          Creating account...
+        } @else {
+          Register
+        }
+      </button>
+    </form>
+
+    <p class="auth-link">
+      Already have an account? <a routerLink="/login" [queryParams]="{ returnUrl: returnUrl }">Log in</a>
+    </p>
+  </div>
+</main>

--- a/src/app/auth/register/register.component.spec.ts
+++ b/src/app/auth/register/register.component.spec.ts
@@ -1,0 +1,213 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RegisterComponent } from './register.component';
+import { AuthResponse } from '../models/auth.models';
+
+function makeJwt(exp: number): string {
+  const h = btoa(JSON.stringify({ alg: 'HS256' }));
+  const b = btoa(JSON.stringify({ sub: 'u1', exp }));
+  return `${h}.${b}.sig`;
+}
+
+const mockResponse: AuthResponse = {
+  token: makeJwt(Date.now() / 1000 + 3600),
+  user: { id: 'u1', email: 'test@example.com', name: 'Test User' }
+};
+
+describe('RegisterComponent', () => {
+  let fixture: ComponentFixture<RegisterComponent>;
+  let component: RegisterComponent;
+  let httpMock: HttpTestingController;
+  let router: Router;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+      imports: [RegisterComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([
+          { path: 'register', component: RegisterComponent },
+          { path: 'dashboard', component: RegisterComponent },
+        ]),
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('form validation', () => {
+    it('is invalid when empty', () => {
+      expect(component.form.invalid).toBe(true);
+    });
+
+    it('shows name required error', () => {
+      component.form.get('name')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-name-error')?.textContent).toContain('required');
+    });
+
+    it('shows email required error', () => {
+      component.form.get('email')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-email-error')?.textContent).toContain('required');
+    });
+
+    it('shows password min length error', () => {
+      component.form.get('password')!.setValue('short');
+      component.form.get('password')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-password-error')?.textContent).toContain('8 characters');
+    });
+
+    it('shows confirm password required error', () => {
+      component.form.get('confirmPassword')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-confirm-password-error')?.textContent).toContain('confirm');
+    });
+
+    it('shows password mismatch error', () => {
+      component.form.get('password')!.setValue('password1');
+      component.form.get('confirmPassword')!.setValue('password2');
+      component.form.get('confirmPassword')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-confirm-password-error')?.textContent).toContain('do not match');
+    });
+
+    it('no mismatch when passwords match', () => {
+      component.form.get('password')!.setValue('password1');
+      component.form.get('confirmPassword')!.setValue('password1');
+      component.form.get('confirmPassword')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-confirm-password-error')).toBeNull();
+    });
+
+    it('sets aria-invalid on invalid touched fields', () => {
+      component.form.get('name')!.markAsTouched();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#register-name').getAttribute('aria-invalid')).toBe('true');
+    });
+  });
+
+  describe('submit', () => {
+    function fillValid() {
+      component.form.get('name')!.setValue('Test');
+      component.form.get('email')!.setValue('test@example.com');
+      component.form.get('password')!.setValue('password1');
+      component.form.get('confirmPassword')!.setValue('password1');
+      fixture.detectChanges();
+    }
+
+    it('does not submit invalid form', () => {
+      component.onSubmit();
+      httpMock.expectNone('/api/auth/register');
+    });
+
+    it('sends register request and navigates on success', () => {
+      fillValid();
+      vi.spyOn(router, 'navigateByUrl');
+      component.onSubmit();
+      expect(component.loading).toBe(true);
+
+      const req = httpMock.expectOne('/api/auth/register');
+      expect(req.request.body.name).toBe('Test');
+      expect(req.request.body.email).toBe('test@example.com');
+      expect(req.request.body.password).toBe('password1');
+      // confirmPassword should NOT be sent
+      expect(req.request.body.confirmPassword).toBeUndefined();
+      req.flush(mockResponse);
+
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/dashboard', { replaceUrl: true });
+    });
+
+    it('shows 409 duplicate email error without clearing form', () => {
+      fillValid();
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/register').flush(
+        { error: 'EMAIL_ALREADY_EXISTS', message: 'Dup' },
+        { status: 409, statusText: 'Conflict' }
+      );
+      expect(component.errorMessage).toBe('Email already in use');
+      expect(component.form.get('email')!.value).toBe('test@example.com');
+      expect(component.loading).toBe(false);
+    });
+
+    it('shows network error on status 0', () => {
+      fillValid();
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/register').error(new ProgressEvent('error'), { status: 0 });
+      expect(component.errorMessage).toContain('Unable to connect');
+    });
+
+    it('shows 429 rate limit message', () => {
+      fillValid();
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/register').flush('', { status: 429, statusText: 'Too Many' });
+      expect(component.errorMessage).toContain('Too many attempts');
+    });
+
+    it('shows 422 field-specific errors', () => {
+      fillValid();
+      component.onSubmit();
+      httpMock.expectOne('/api/auth/register').flush(
+        { error: 'VALIDATION_ERROR', message: 'Validation', details: [{ field: 'email', message: 'Invalid domain' }] },
+        { status: 422, statusText: 'Unprocessable' }
+      );
+      expect(component.errorMessage).toContain('Invalid domain');
+    });
+
+    it('prevents double submit', () => {
+      fillValid();
+      component.onSubmit();
+      component.onSubmit();
+      expect(httpMock.match('/api/auth/register').length).toBe(1);
+    });
+  });
+
+  describe('password visibility', () => {
+    it('toggles password visibility', () => {
+      expect(component.showPassword).toBe(false);
+      component.togglePasswordVisibility();
+      expect(component.showPassword).toBe(true);
+    });
+
+    it('toggles confirm password visibility', () => {
+      expect(component.showConfirmPassword).toBe(false);
+      component.toggleConfirmPasswordVisibility();
+      expect(component.showConfirmPassword).toBe(true);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has visible labels for all inputs', () => {
+      expect(fixture.nativeElement.querySelector('label[for="register-name"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('label[for="register-email"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('label[for="register-password"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('label[for="register-confirm-password"]')).toBeTruthy();
+    });
+
+    it('has h1 heading', () => {
+      expect(fixture.nativeElement.querySelector('h1')?.textContent).toContain('Create your account');
+    });
+
+    it('uses main landmark', () => {
+      expect(fixture.nativeElement.querySelector('main')).toBeTruthy();
+    });
+  });
+});

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -1,0 +1,122 @@
+import { Component, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { Router, RouterLink, ActivatedRoute } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subscription } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { trackEvent } from '../../shared/utils/analytics';
+
+function sanitizeReturnUrl(url: string): string {
+  if (url && url.startsWith('/') && !url.startsWith('//')) {
+    return url;
+  }
+  return '/dashboard';
+}
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './register.component.html',
+  styleUrl: './register.component.css'
+})
+export class RegisterComponent implements OnDestroy {
+  form: FormGroup;
+  loading = false;
+  errorMessage = '';
+  showPassword = false;
+  showConfirmPassword = false;
+
+  protected readonly returnUrl: string;
+
+  private subscription?: Subscription;
+  private timeoutId?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly auth: AuthService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute
+  ) {
+    this.returnUrl = sanitizeReturnUrl(this.route.snapshot.queryParams['returnUrl'] || '/dashboard');
+    this.form = this.fb.group({
+      name: ['', { validators: [Validators.required], updateOn: 'blur' }],
+      email: ['', { validators: [Validators.required, Validators.email], updateOn: 'blur' }],
+      password: ['', { validators: [Validators.required, Validators.minLength(8)], updateOn: 'blur' }],
+      confirmPassword: ['', { validators: [Validators.required], updateOn: 'blur' }]
+    }, { validators: [RegisterComponent.passwordMatchValidator] });
+  }
+
+  static passwordMatchValidator(group: AbstractControl): ValidationErrors | null {
+    const password = group.get('password')?.value;
+    const confirmPassword = group.get('confirmPassword')?.value;
+    if (confirmPassword && password !== confirmPassword) {
+      return { passwordMismatch: true };
+    }
+    return null;
+  }
+
+  togglePasswordVisibility(): void {
+    this.showPassword = !this.showPassword;
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
+  }
+
+  toggleConfirmPasswordVisibility(): void {
+    this.showConfirmPassword = !this.showConfirmPassword;
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.loading) {
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+    this.form.disable();
+
+    const { name, email, password } = this.form.getRawValue();
+
+    this.timeoutId = setTimeout(() => {
+      this.loading = false;
+      this.form.enable();
+      this.errorMessage = 'Request timed out. Please try again.';
+    }, 10000);
+
+    this.subscription = this.auth.register(name, email, password).subscribe({
+      next: () => {
+        clearTimeout(this.timeoutId);
+        this.router.navigateByUrl(this.returnUrl, { replaceUrl: true });
+      },
+      error: (err: HttpErrorResponse) => {
+        clearTimeout(this.timeoutId);
+        this.loading = false;
+        this.form.enable();
+        this.errorMessage = this.mapError(err);
+        trackEvent('auth_register_failure', { reason: this.errorMessage });
+      }
+    });
+  }
+
+  private mapError(err: HttpErrorResponse): string {
+    if (err.status === 0) {
+      return 'Unable to connect. Please check your connection and try again.';
+    }
+    if (err.status === 409) {
+      return 'Email already in use';
+    }
+    if (err.status === 422 && err.error?.details?.length) {
+      return err.error.details.map((d: { field: string; message: string }) => d.message).join('. ');
+    }
+    if (err.status === 429) {
+      return 'Too many attempts. Please wait and try again.';
+    }
+    return 'Something went wrong. Please try again.';
+  }
+}

--- a/src/app/auth/services/auth.service.spec.ts
+++ b/src/app/auth/services/auth.service.spec.ts
@@ -1,0 +1,163 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { AuthResponse } from '../models/auth.models';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+const mockUser = { id: 'u1', email: 'test@example.com', name: 'Test' };
+const validToken = makeJwt({ sub: 'u1', email: 'test@example.com', exp: Date.now() / 1000 + 3600, iat: Date.now() / 1000 });
+const expiredToken = makeJwt({ sub: 'u1', email: 'test@example.com', exp: Date.now() / 1000 - 100, iat: Date.now() / 1000 - 3700 });
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+  let router: Router;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+      ]
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('isAuthenticated', () => {
+    it('returns false when no token', () => {
+      expect(service.isAuthenticated()).toBe(false);
+    });
+
+    it('returns true for valid token', () => {
+      localStorage.setItem('auth_token', validToken);
+      expect(service.isAuthenticated()).toBe(true);
+    });
+
+    it('returns false for expired token', () => {
+      localStorage.setItem('auth_token', expiredToken);
+      expect(service.isAuthenticated()).toBe(false);
+    });
+
+    it('returns false for malformed token', () => {
+      localStorage.setItem('auth_token', 'garbage');
+      expect(service.isAuthenticated()).toBe(false);
+    });
+  });
+
+  describe('hydration on construction', () => {
+    it('hydrates user from valid token in localStorage', () => {
+      localStorage.setItem('auth_token', validToken);
+      localStorage.setItem('auth_user', JSON.stringify(mockUser));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+      });
+      const fresh = TestBed.inject(AuthService);
+      expect(fresh.currentUser).toBeTruthy();
+    });
+
+    it('clears storage if token is expired', () => {
+      localStorage.setItem('auth_token', expiredToken);
+      localStorage.setItem('auth_user', JSON.stringify(mockUser));
+      // Need new injector to test constructor
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+      });
+      const svc = TestBed.inject(AuthService);
+      expect(svc.currentUser).toBeNull();
+      expect(localStorage.getItem('auth_token')).toBeNull();
+    });
+
+    it('clears storage if token is malformed', () => {
+      localStorage.setItem('auth_token', 'not.valid');
+      localStorage.setItem('auth_user', JSON.stringify(mockUser));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+      });
+      const svc = TestBed.inject(AuthService);
+      expect(svc.currentUser).toBeNull();
+    });
+  });
+
+  describe('login', () => {
+    it('sends lowercase email and stores token on success', () => {
+      const response: AuthResponse = { token: validToken, user: mockUser };
+      service.login('Test@Example.COM', 'password1').subscribe(res => {
+        expect(res.user.email).toBe('test@example.com');
+      });
+      const req = httpMock.expectOne('/api/auth/login');
+      expect(req.request.body.email).toBe('test@example.com');
+      req.flush(response);
+      expect(localStorage.getItem('auth_token')).toBe(validToken);
+      expect(service.currentUser).toEqual(mockUser);
+    });
+
+    it('trims email whitespace', () => {
+      service.login('  test@example.com  ', 'password1').subscribe();
+      const req = httpMock.expectOne('/api/auth/login');
+      expect(req.request.body.email).toBe('test@example.com');
+      req.flush({ token: validToken, user: mockUser });
+    });
+  });
+
+  describe('register', () => {
+    it('sends lowercase email and stores token on success', () => {
+      const response: AuthResponse = { token: validToken, user: mockUser };
+      service.register('Test', 'Test@Example.COM', 'password1').subscribe();
+      const req = httpMock.expectOne('/api/auth/register');
+      expect(req.request.body.email).toBe('test@example.com');
+      expect(req.request.body.name).toBe('Test');
+      req.flush(response);
+      expect(localStorage.getItem('auth_token')).toBe(validToken);
+      expect(service.currentUser).toEqual(mockUser);
+    });
+  });
+
+  describe('logout', () => {
+    it('clears token, user, and navigates to /login', () => {
+      vi.spyOn(router, 'navigateByUrl');
+      localStorage.setItem('auth_token', validToken);
+      localStorage.setItem('auth_user', JSON.stringify(mockUser));
+
+      service.logout();
+
+      expect(localStorage.getItem('auth_token')).toBeNull();
+      expect(localStorage.getItem('auth_user')).toBeNull();
+      expect(service.currentUser).toBeNull();
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/login', { replaceUrl: true });
+    });
+  });
+
+  describe('getToken', () => {
+    it('returns token from localStorage', () => {
+      localStorage.setItem('auth_token', 'abc');
+      expect(service.getToken()).toBe('abc');
+    });
+
+    it('returns null when no token', () => {
+      expect(service.getToken()).toBeNull();
+    });
+  });
+});

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { AuthUser, AuthResponse, LoginRequest, RegisterRequest } from '../models/auth.models';
+import { trackEvent } from '../../shared/utils/analytics';
+
+const TOKEN_KEY = 'auth_token';
+const USER_KEY = 'auth_user';
+
+/**
+ * AuthService is the single source of truth for authentication state.
+ *
+ * Tradeoffs documented:
+ * - localStorage is used for JWT storage (XSS vector). Follow-up story will migrate to httpOnly cookies.
+ * - On bootstrap, the JWT is trusted locally (no /api/auth/me call). The interceptor's 401 catch
+ *   handles server-side rejection of stale/revoked tokens.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly currentUserSubject: BehaviorSubject<AuthUser | null>;
+  readonly currentUser$: Observable<AuthUser | null>;
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly router: Router
+  ) {
+    this.currentUserSubject = new BehaviorSubject<AuthUser | null>(this.hydrateUser());
+    this.currentUser$ = this.currentUserSubject.asObservable();
+  }
+
+  get currentUser(): AuthUser | null {
+    return this.currentUserSubject.value;
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  isAuthenticated(): boolean {
+    const token = this.getToken();
+    if (!token) {
+      return false;
+    }
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      return payload.exp > Date.now() / 1000;
+    } catch {
+      return false;
+    }
+  }
+
+  login(email: string, password: string): Observable<AuthResponse> {
+    const request: LoginRequest = { email: email.toLowerCase().trim(), password };
+    trackEvent('auth_login_attempt', { timestamp: Date.now() });
+
+    return this.http.post<AuthResponse>('/api/auth/login', request).pipe(
+      tap(response => {
+        this.handleAuthSuccess(response);
+        trackEvent('auth_login_success', { userId: response.user.id });
+      })
+    );
+  }
+
+  register(name: string, email: string, password: string): Observable<AuthResponse> {
+    const request: RegisterRequest = { name: name.trim(), email: email.toLowerCase().trim(), password };
+    trackEvent('auth_register_attempt', { timestamp: Date.now() });
+
+    return this.http.post<AuthResponse>('/api/auth/register', request).pipe(
+      tap(response => {
+        this.handleAuthSuccess(response);
+        trackEvent('auth_register_success', { userId: response.user.id });
+      })
+    );
+  }
+
+  logout(): void {
+    const userId = this.currentUser?.id;
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+    this.currentUserSubject.next(null);
+    if (userId) {
+      trackEvent('auth_logout', { userId });
+    }
+    this.router.navigateByUrl('/login', { replaceUrl: true });
+  }
+
+  private handleAuthSuccess(response: AuthResponse): void {
+    localStorage.setItem(TOKEN_KEY, response.token);
+    localStorage.setItem(USER_KEY, JSON.stringify(response.user));
+    this.currentUserSubject.next(response.user);
+  }
+
+  /**
+   * Synchronously hydrate user from localStorage on construction.
+   * If token is expired, malformed, or decoding throws, clear storage silently.
+   */
+  private hydrateUser(): AuthUser | null {
+    const token = localStorage.getItem(TOKEN_KEY);
+    const userJson = localStorage.getItem(USER_KEY);
+    if (!token || !userJson) {
+      return null;
+    }
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      if (payload.exp <= Date.now() / 1000) {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
+        return null;
+      }
+      return JSON.parse(userJson) as AuthUser;
+    } catch {
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
+      return null;
+    }
+  }
+}

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+import { AuthService } from '../auth/services/auth.service';
+import { BehaviorSubject } from 'rxjs';
+import { AuthUser } from '../auth/models/auth.models';
+
+describe('DashboardComponent', () => {
+  let fixture: ComponentFixture<DashboardComponent>;
+  let component: DashboardComponent;
+  let mockUser$: BehaviorSubject<AuthUser | null>;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    mockUser$ = new BehaviorSubject<AuthUser | null>({ id: 'u1', email: 'a@b.com', name: 'Alice' });
+
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser$: mockUser$.asObservable(),
+            logout: vi.fn(),
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('displays welcome message with user name', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('h1')?.textContent).toContain('Welcome, Alice');
+  });
+
+  it('has a logout button', () => {
+    const btn = fixture.nativeElement.querySelector('.logout-btn') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toContain('Log out');
+  });
+
+  it('calls logout when button clicked', () => {
+    const authService = TestBed.inject(AuthService);
+    const btn = fixture.nativeElement.querySelector('.logout-btn') as HTMLButtonElement;
+    btn.click();
+    expect(authService.logout).toHaveBeenCalled();
+  });
+
+  it('does not show content when user is null', () => {
+    mockUser$.next(null);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('h1')).toBeNull();
+  });
+});

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AuthService } from '../auth/services/auth.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="dashboard">
+      @if (auth.currentUser$ | async; as user) {
+        <h1>Welcome, {{ user.name }}</h1>
+        <button (click)="auth.logout()" class="logout-btn">Log out</button>
+      }
+    </div>
+  `,
+  styles: [`
+    .dashboard {
+      padding: 2rem;
+      text-align: center;
+    }
+    h1 {
+      margin-bottom: 1rem;
+    }
+    .logout-btn {
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+    }
+    .logout-btn:hover {
+      background: #f5f5f5;
+    }
+  `]
+})
+export class DashboardComponent {
+  constructor(readonly auth: AuthService) {}
+}

--- a/src/app/shared/utils/analytics.ts
+++ b/src/app/shared/utils/analytics.ts
@@ -1,0 +1,8 @@
+/**
+ * Lightweight analytics stub. Logs events to console in development.
+ * Replace with a real analytics provider (e.g., Segment, Amplitude) in a follow-up story.
+ */
+export function trackEvent(name: string, properties: Record<string, unknown> = {}): void {
+  // eslint-disable-next-line no-console
+  console.log(`[Analytics] ${name}`, { ...properties, timestamp: new Date().toISOString() });
+}


### PR DESCRIPTION
## ⚠️ Pipeline Failed

**Reason:** Pipeline failed after 2 loop(s). Tests are FAILING.

### Test Failures
```
Test failed (`npm run test`):

> my-test-app@0.0.0 test
> ng test

[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                           [2m | [22m[1mNames[22m                                      [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                               [2m | [22m[2mspec-app-app[22m                               [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mspec-app-auth-register-register.component.js[39m  [2m | [22m[2mspec-app-auth-register-register.component[22m  [2m | [22m [36m35.52 kB[39m[2m | [22m
[32mspec-app-auth-login-login.component.js[39m        [2m | [22m[2mspec-app-auth-login-login.component[22m        [2m | [22m [36m29.10 kB[39m[2m | [22m
[32mspec-app-auth-services-auth.service.js[39m        [2m | [22m[2mspec-app-auth-services-auth.service[22m        [2m | [22m  [36m5.92 kB[39m[2m | [22m
[32mspec-app-dashboard-dashboard.component.js[39m     [2m | [22m[2mspec-app-dashboard-dashboard.component[22m     [2m | [22m  [36m5.83 kB[39m[2m | [22m
[32mchunk-RSTWSNOR.js[39m                             [2m | [22m[2m-[22m                                          [2m | [22m  [36m4.75 kB[39m[2m | [22m
[32mspec-app-auth-interceptors-auth.interceptor.js[39m[2m | [22m[2mspec-app-auth-interceptors-auth.interceptor[22m[2m | [22m  [36m4.13 kB[39m[2m | [22m
[32mchunk-2Y5YIAIU.js[39m                             [2m | [22m[2m-[22m         
… (truncated)
```

### Diagnostic
Pipeline exhausted after 2 review loop(s).

### Test Failures
```
Test failed (`npm run test`):

> my-test-app@0.0.0 test
> ng test

[33m❯[39m Building...
[32m✔[39m Building...
[1mInitial chunk files[22m                           [2m | [22m[1mNames[22m                                      [2m | [22m [1mRaw size[22m
[32mspec-app-app.js[39m                               [2m | [22m[2mspec-app-app[22m                               [2m | [22m [36m47.23 kB[39m[2m | [22m
[32mspec-app-auth-register-register.component.js[39m  [2m | [22m[2mspec-app-auth-register-register.component[22m  [2m | [22m [36m35.52 kB[39m[2m | [22m
[32mspec-app-auth-login-login.component.js[39m        [2m | [22m[2mspec-app-auth-login-login.component[22m        [2m | [22m [36m29.10 kB[39m[2m | [22m
[32mspec-app-auth-services-auth.service.js[39m        [2m | [22m[2mspec-app-auth-services-auth.service[22m        [2m | [22m  [36m5.92 kB[39m[2m | [22m
[32mspec-app-dashboard-dashboard.component.js[39m     [2m | [22m[2mspec-app-dashboard-dashboard.component[22m     [2m | [22m  [36m5.83 kB[39m[2m | [22m
[32mchunk-RSTWSNOR.js[39m                             [2m | [22m[2m-[22m                                          [2m | [22m  [36m4.75 kB[39m[2m | [22m
[32mspec-app-auth-interceptors-auth.interceptor.js[39m[2m | [22m[2mspec-app-auth-interceptors-auth.interceptor[22m[2m | [22m  [36m4.13 kB[39m[2m | [22m
[32mchunk-2Y5YIAIU.js[39m                             [2m | [22m[2m-[22m         
… (truncated)
```

### Recommended Next Steps
- Review the issues above and provide `--guidance` on the next run
- Re-run with the same `branch` input to continue from this code state

### How to Continue

**Option 1:** Comment on this PR:
`/bmad retry Your guidance here`

**Option 2:** Manual dispatch:
```
gh workflow run bmad-start-run.yml \
  -f target_repo="diegosramirez/my-test-app" \
  -f branch="bmad/sam1/SAM1-374-create-a-more-advanced-full-stack-saas-s" \
  -f prompt="Create a more advanced full-stack SaaS-style application with Angular frontend and backend with data" \
  -f team_id="SAM1" \
  -f skip_check_epic_state=true \
  -f skip_create_or_correct_epic=true \
  -f skip_create_story_tasks=true \
  -f skip_party_mode_refinement=true \
  -f extra_flags="--story-key SAM1-374 --retry"
```

---
## Story
**SAM1-374**: **Hypothesis**

## Acceptance Criteria
- Given a visitor on /register, when they submit valid name, email, password, and matching confirm password, then a new user is created, JWT is returned and stored in localStorage, and they are redirected to returnUrl query param or /dashboard with replaceUrl: true
- Given an email already exists (case-insensitive), when a visitor tries to register with that email, then a 409 error is returned and an inline error message is displayed above the submit button without clearing the form
- Given a registered user on /login, when they submit correct email and password, then a JWT is returned and stored, and they are redirected to returnUrl query param or /dashboard with replaceUrl: true
- Given a visitor on /login, when they submit wrong email or password, then a 401 error is returned and an inline error message is displayed above the submit button without clearing the form; network errors and 429 responses display distinct, appropriate messages
- Given an unauthenticated user, when they navigate to any protected route, then the AuthGuard redirects to /login?returnUrl={originalRoute} and after successful login they are redirected to that original route
- Given an authenticated user, when any HTTP request is made to a /api/ endpoint then the JWT Bearer token is included in the Authorization header; when any API call returns 401 then the interceptor clears the token, nulls auth state, and redirects to /login
- Given a user on login or register, when they blur a field that is empty, has invalid email format, password under 8 characters, or mismatched confirm password, then an inline validation error with aria-describedby and aria-invalid is shown beneath the relevant input, the submit button remains disabled, and no API call is made; all inputs have visible labels, password fields have a visibility toggle, and paste is not disabled
- Given the app loads with a token in localStorage, when the token is valid then the user proceeds to their requested route with no flash of login page; when the token is expired or malformed then localStorage is cleared silently and the user is redirected to /login

## Implementation Details
### Architecture


# Technical Architecture Review: Authentication Flow

## Data Model Changes

**User Entity**

The `User` entity is the only new data model required at this stage. Define it with the following shape on the backend:

```
User {
  id: UUID (primary key, server-generated)
  email: string (unique constraint, indexed, lowercase-normalized)
  passwordHash: string (bcrypt, cost factor 12+)
  name: string (non-empty, trimmed)
  createdAt: DateTime (server-generated, UTC)
  updatedAt: DateTime (server-generated, UTC)
}
```

- Never store plaintext passwords. The `passwordHash` column stores the bcrypt

### Developer Notes
**Frontend-Only Scope — Mock the Backend**
The project context is Angular-only. Build against the defined API contract and test with `provideHttpClientTesting()` and mocked HTTP responses. Consider `json-server` or MSW for manual dev testing. Do not block on backend availability. If a backend is expected in this story, scope must be renegotiated.

**Build Order**
Models → AuthService → Interceptor → Guard → Components → Routes → App Config → Dashboard → Tests. Bottom-up ensures each layer's dependencies exist before it is built.

**AuthService Hydration on Bootstrap**
Synchronously decode the 

## Files Changed
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.config.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/app.routes.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/guards/auth.guard.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/guards/auth.guard.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/interceptors/auth.interceptor.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/interceptors/auth.interceptor.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/login/login.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/login/login.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/login/login.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/login/login.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/models/auth.models.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/register/register.component.css`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/register/register.component.html`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/register/register.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/register/register.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/services/auth.service.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/auth/services/auth.service.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/dashboard/dashboard.component.spec.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/dashboard/dashboard.component.ts`
- `/home/runner/work/bmad-orchestrator/bmad-orchestrator/target-repo/src/app/shared/utils/analytics.ts`

## QA Additions
- `agent_self_verified`: ✅ passed

## Code Review Resolution
Pipeline failed with 0 unresolved issue(s) after 2 review loop(s).

---
*Generated by BMAD Autonomous Engineering Orchestrator* 🤖

<!-- bmad:target_repo=diegosramirez/my-test-app -->
<!-- bmad:prompt=Create a more advanced full-stack SaaS-style application with Angular frontend and backend with database, migrations, authentication, and authorization.  Important: - Delete all scaffolded Angular app -->
<!-- bmad:team_id=SAM1 -->